### PR TITLE
Support setting fill and background colors of toolbar buttons

### DIFF
--- a/src/editor-toolbar/editor-toolbar.stories.js
+++ b/src/editor-toolbar/editor-toolbar.stories.js
@@ -70,3 +70,12 @@ export const Vertical = () => (
     buttons={buttons}
     />
 );
+
+export const Colored = () => (
+  <EditorToolbar
+    orientation="vertical"
+    colors={{ background: "#177991", fill: "#ffffff" }}
+    iconSize={16}
+    buttons={buttons}
+    />
+);

--- a/src/editor-toolbar/editor-toolbar.tsx
+++ b/src/editor-toolbar/editor-toolbar.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef } from "react";
-import { IBaseProps, ToolbarButton } from "./toolbar-button";
+import { IBaseProps, IColors, ToolbarButton } from "./toolbar-button";
 import { Editor } from "slate-react";
 import { SelectionJSON } from "slate";
 
@@ -10,6 +10,8 @@ export interface IButtonSpec extends IBaseProps {
 export interface IProps {
   className?: string;
   orientation?: "horizontal" | "vertical";
+  colors?: IColors;
+  selectedColors?: IColors;
   buttonsPerRow?: number;
   iconSize?: number;
   buttonSize?: number;
@@ -37,14 +39,17 @@ export const EditorToolbar: React.FC<IProps> = (iProps: IProps) => {
   // console.log("SlateEditor.renderCount:", ++renderCount);
 
   const props = { ...kDefaultProps, ...iProps } as Required<IProps>;
-  const { orientation, buttonsPerRow, iconSize, buttonSize, buttons, editor } = props;
+  const { orientation, colors, selectedColors, buttonsPerRow, iconSize, buttonSize, buttons, editor } = props;
   const longAxisButtonCount = buttonsPerRow || buttons.length;
   const crossAxisButtonCount = buttonsPerRow ? Math.ceil(buttons.length / buttonsPerRow) : 1;
   const toolbarLongExtent = longAxisButtonCount * buttonSize;
   const toolbarCrossExtent = crossAxisButtonCount * buttonSize;
-  const toolbarStyle = orientation === "vertical"
+  const toolbarSize = orientation === "vertical"
           ? { width: toolbarCrossExtent, height: toolbarLongExtent }
           : { width: toolbarLongExtent, height: toolbarCrossExtent };
+  const toolbarStyle = colors?.background
+                        ? { backgroundColor: colors.background, ...toolbarSize }
+                        : toolbarSize;
   const orientationClass = orientation || "horizontal";
 
   // By default, clicking on a button (such as a toolbar button) takes focus from an
@@ -70,6 +75,7 @@ export const EditorToolbar: React.FC<IProps> = (iProps: IProps) => {
             const _iconSize = button.iconSize || iconSize;
             return (
               <ToolbarButton key={`key-${format}`} format={format} iconSize={_iconSize} buttonSize={buttonSize}
+                colors={colors} selectedColors={selectedColors}
                 onSaveSelection={handleSaveSelection} onRestoreSelection={handleRestoreSelection} {...others} />
             );
           })

--- a/src/editor-toolbar/toolbar-button.tsx
+++ b/src/editor-toolbar/toolbar-button.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { CSSProperties } from "react";
 import { IconProps } from "../assets/icon-props";
 
 export type OnMouseFn = (e: React.MouseEvent<HTMLDivElement>) => void;
@@ -6,9 +6,19 @@ export type OnClickFn = (format: string, e: React.MouseEvent<HTMLDivElement>) =>
 export type OnChangeColorFn = (color: string) => void;
 export type OnChangeFn = OnChangeColorFn;
 
+const kDefaultFillColor = "#909090";
+const kDefaultSelectedFillColor = "#009CDC";
+
+export interface IColors {
+  fill?: string;
+  background?: string;
+}
+
 export interface IBaseProps {
   format: string;
   SvgIcon: (props: IconProps) => JSX.Element;
+  colors?: IColors;
+  selectedColors?: IColors;
   tooltip: string;
   isActive: boolean;
   onMouseDown?: OnMouseFn;
@@ -22,9 +32,9 @@ export interface IProps extends IBaseProps {
   buttonSize: number;
 }
 export const ToolbarButton: React.FC<IProps> = (props: IProps) => {
-  const { format, SvgIcon, iconSize, buttonSize, tooltip, isActive,
+  const { format, SvgIcon, iconSize, buttonSize, tooltip, isActive, colors, selectedColors,
           onChange, onClick, onMouseDown, onSaveSelection, onRestoreSelection } = props;
-  const buttonStyle = {
+  const buttonStyle: CSSProperties = {
           width: buttonSize,
           height: buttonSize
         };
@@ -32,7 +42,15 @@ export const ToolbarButton: React.FC<IProps> = (props: IProps) => {
           width: iconSize,
           height: iconSize
         };
-  const fill = isActive ? "#009CDC" : "#909090";
+  const fill = isActive
+                ? (selectedColors?.fill || kDefaultSelectedFillColor)
+                : (colors?.fill || kDefaultFillColor);
+  if (isActive && selectedColors?.background) {
+    buttonStyle.backgroundColor = selectedColors.background;
+  }
+  if (!isActive && colors?.background) {
+    buttonStyle.backgroundColor = colors.background;
+  }
   const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
     onSaveSelection?.();
     onMouseDown?.(e);

--- a/src/slate-container/slate-container.stories.js
+++ b/src/slate-container/slate-container.stories.js
@@ -14,6 +14,28 @@ export const Combined = () => {
   );
 };
 
+const coloredText = "This example demonstrates a toolbar with custom colors with the selection indicated by a change in the fill color.";
+
+export const ColoredToolbarSelectedFill = () => {
+  const [value, setValue] = useState(coloredText);
+  return (
+    <SlateContainer value={value} onValueChange={_value => setValue(_value)}
+    toolbar={{ colors: { fill: "#ffffff", background: "#177991" },
+                selectedColors: { fill: "#72bfca", background: "#177991" } }} />
+  );
+};
+
+const backgroundText = "This example demonstrates a toolbar with custom colors with the selection indicated by a change in the fill and background colors.";
+
+export const ColoredToolbarSelectedBackground = () => {
+  const [value, setValue] = useState(backgroundText);
+  return (
+    <SlateContainer value={value} onValueChange={_value => setValue(_value)}
+    toolbar={{ colors: { fill: "#ffffff", background: "#177991" },
+                selectedColors: { fill: "#177991", background: "#72bfca" } }} />
+  );
+};
+
 const portalText = "This example demonstrates rendering the toolbar in a React portal (so" +
                   " it can be attached at an arbitrary point in the DOM outside the React" +
                   " hierarchy) as well as hiding/showing the toolbar on blur/focus.";


### PR DESCRIPTION
Storybook examples use CODAP colors because I was playing around with combinations to see what might work for CODAP.

Note that while fill color has to be specified this way because it can't be set from CSS, we could eliminate the props support for background-color and rely on CSS for that, but it seemed simpler to let clients specify all the colors in one place.