### PR TITLE
Selecting black clears the color mark

### DIFF
--- a/src/plugins/color-plugin.tsx
+++ b/src/plugins/color-plugin.tsx
@@ -23,8 +23,9 @@ export const colorPlugin: Plugin = {
   },
   commands: {
     setColorMark: function(editor: Editor, color: string) {
+      const kBlackColor = "#000000";
       removeColorMarksFromSelection(editor);
-      editor.addMark({ type: EFormat.color, data: { color } });
+      (color !== kBlackColor) && editor.addMark({ type: EFormat.color, data: { color } });
       return editor;
     }
   }


### PR DESCRIPTION
Previously, once a block of text had a color mark there was no way to clear it. Since black is the default text color, if the user selects black we simply clear the color mark, which unhighlights the color button on the toolbar.