### PR TITLE
Fit editor inside its container better with `box-sizing: border-box`

### DIFF
--- a/src/slate-editor/slate-editor.scss
+++ b/src/slate-editor/slate-editor.scss
@@ -1,4 +1,5 @@
 .slate-editor {
+  box-sizing: border-box;
   padding: 3px;
   overflow-y: auto;
 


### PR DESCRIPTION
May fix or improve the behavior of [#172721106](https://www.pivotaltracker.com/story/show/172721106).