### PR TITLE
Add `serializeSelection()`; add storybook example showing current selection

### DIFF
--- a/src/slate-editor/serialization.ts
+++ b/src/slate-editor/serialization.ts
@@ -100,6 +100,13 @@ export function serializeDocument(document: DocumentJSON): SlateDocument {
   return { ...keyProp(key), children, objTypes, ...data };
 }
 
+export function serializeSelection(value: Value) {
+  const { document, selection } = value;
+  const nodes = document.getDescendantsAtRange(selection).toArray();
+  const objTypes: ObjectTypeMap = {};
+  return nodes.map(node => serializeNode(node.toJSON(), objTypes));
+}
+
 export function serializeValueJSON(value: ValueJSON): SlateExchangeValue {
   const { data: _data, document } = value;
   const { undos, redos, ...others } = _data || {};

--- a/src/slate-editor/slate-serialization.stories.js
+++ b/src/slate-editor/slate-serialization.stories.js
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { SlateContainer } from "../slate-container/slate-container";
 import { textToSlate } from "../common/slate-types";
-import { serializeValue } from "./serialization";
+import { serializeSelection, serializeValue } from "./serialization";
 import "./slate-serialization.stories.scss";
 
 export default {
@@ -11,22 +11,43 @@ export default {
 const serializationText = "This example shows the serialized editor content.";
 
 export const Serialization = () => {
-  const [value, setValue] = useState(serializationText);
   const slateValue = textToSlate(serializationText);
-  const serializedValue = serializeValue(slateValue.toJSON());
-  const [content, setContent] = useState(serializedValue);
+  const [value, setValue] = useState(slateValue);
+  const [content, setContent] = useState(serializeValue(value.toJSON()));
   return (
     <div className="serialization-container">
       <div className="panel">
-        <SlateContainer 
-          value={value} 
-          onValueChange={_value => setValue(_value)} 
-          onContentChange={_content => setContent(_content)} 
-        />        
+        <SlateContainer
+          value={value}
+          onValueChange={_value => setValue(_value)}
+          onContentChange={_content => setContent(_content)}
+        />
       </div>
       <div className="panel output">
         <h3>Serialized Content</h3>
         <pre>{JSON.stringify(content, null, 2)}</pre>
+      </div>
+    </div>
+  );
+};
+
+const selectionSerializationText = "This example shows the serialized selection content determined by calling getDescendantsAtRange().";
+
+export const SelectionSerialization = () => {
+  const slateValue = textToSlate(selectionSerializationText);
+  const [value, setValue] = useState(slateValue);
+  const serializedSelection = serializeSelection(value);
+  return (
+    <div className="serialization-container">
+      <div className="panel">
+        <SlateContainer
+          value={value}
+          onValueChange={_value => setValue(_value)}
+        />
+      </div>
+      <div className="panel output">
+        <h3>Serialized Selection</h3>
+        <pre>{JSON.stringify(serializedSelection, null, 2)}</pre>
       </div>
     </div>
   );

--- a/src/slate-editor/slate-serialization.stories.scss
+++ b/src/slate-editor/slate-serialization.stories.scss
@@ -8,8 +8,12 @@
   .output {
     background-color: #F0F0F0;
     padding: 5px 10px 15px 10px;
-  }  
+
+    pre {
+      white-space: pre-wrap;
+    }
+  }
   h3 {
     margin: 5px 0px 5px 0px;
-  }  
+  }
 }


### PR DESCRIPTION
The new storybook example shows the serialized contents of the selection dynamically in the same way that the serialization example shows the serialized contents of the entire Slate value, which is useful for understanding how selection is handled and can be queried.