### PR TITLE
Fix html serialization

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,10 +3,10 @@ export { Editor } from "slate-react";
 export { EditorContent, EditorValue, slateToText, textToSlate } from "./common/slate-types";
 export { HtmlSerializablePlugin } from "./plugins/html-serializable-plugin";
 export { htmlToSlate, slateToHtml } from "./serialization/html-serializer";
-export { deserializeDocument, deserializeValue, serializeDocument, serializeValue, SlateDocument
-        } from "./serialization/serialization";
+export { deserializeDocument, deserializeValue, serializeDocument, serializeValue,
+        SlateDocument, SlateExchangeValue } from "./serialization/serialization";
 export { SlateContainer } from "./slate-container/slate-container";
-export { SlateEditor, SlateExchangeValue } from "./slate-editor/slate-editor";
+export { SlateEditor } from "./slate-editor/slate-editor";
 export { getContentHeight } from "./slate-editor/slate-utils";
 export { DisplayDialogFunction, DisplayDialogSettings, IToolOrder, OrderEntry, SlateToolbar
         } from "./slate-toolbar/slate-toolbar";

--- a/src/plugins/core-marks-plugin.tsx
+++ b/src/plugins/core-marks-plugin.tsx
@@ -3,7 +3,7 @@ import { Mark } from "slate";
 import { RenderAttributes, RenderMarkProps } from "slate-react";
 import { getRenderIndexOfMark } from "../slate-editor/slate-utils";
 import { EFormat } from "../common/slate-types";
-import { getRenderAttributesFromNode, getDataFromElement } from "../serialization/html-utils";
+import { getRenderAttributesFromNode } from "../serialization/html-utils";
 import { HtmlSerializablePlugin } from "./html-serializable-plugin";
 
 function renderMarkAsTag(tag: string, mark: Mark, attributes: RenderAttributes,
@@ -90,7 +90,16 @@ export function CoreMarksPlugin(): HtmlSerializablePlugin {
         return {
           object: "mark",
           type: format,
-          ...getDataFromElement(el, { [format]: tag }),
+          // Adding data attributes in this way allows us to (1) preserve the original tag (e.g. <b> vs. <strong>)
+          // and (2) preserve any attributes that may have been associated with the tag. Unfortunately, it also
+          // wreaks havoc with Slate's mark management because marks are compared by value, so two bold marks
+          // with different tags/attributes no longer compare as equal resulting in toggleMark() not working as
+          // expected, neighboring bold marks not being combined properly, etc. Given that of the original
+          // benefits, we are not taking advantage of (1) because we are following TinyMCE's example and simply
+          // converting legacy tags to their current equivalents and there are no known examples of attributes
+          // being applied to mark tags (2), we simply disable this functionality for now. Leaving it commented
+          // out for now in case we encounter an argument for going back.
+          // ...getDataFromElement(el, { [format]: tag }),
           nodes: next(el.childNodes),
         };
       }

--- a/src/serialization/html-serializer.test.tsx
+++ b/src/serialization/html-serializer.test.tsx
@@ -44,8 +44,9 @@ describe("htmlToSlate(), slateToHtml()", () => {
 
   it("can [de]serialize class and style attributes", () => {
     [
-      `<p><em class="em-class">mark with class</em></p>`,
-      `<p><em style="font-style:italic">mark with inline style</em></p>`,
+      // We no longer preserve attributes associated with mark tags
+      // `<p><em class="em-class">mark with class</em></p>`,
+      // `<p><em style="font-style:italic">mark with inline style</em></p>`,
       `<p class="foo-class bar-class">paragraph with classes</p>`,
       `<p style="float:right">paragraph with inline style</p>`,
       `<p style="float:right;text-align:center">paragraph with multiple inline styles</p>`

--- a/src/serialization/serialization.stories.js
+++ b/src/serialization/serialization.stories.js
@@ -22,7 +22,7 @@ export const Serialization = () => {
         <SlateContainer
           value={value}
           onValueChange={_value => setValue(_value)}
-          onContentChange={_content => setContent(_content)}
+          onContentChange={_value => setContent(serializeValue(_value))}
         />
       </div>
       <div className="panel output">

--- a/src/serialization/serialization.ts
+++ b/src/serialization/serialization.ts
@@ -4,7 +4,6 @@ import keys from "lodash/keys";
 import map from "lodash/map";
 import size from "lodash/size";
 import values from "lodash/values";
-import { SlateExchangeValue } from "../slate-editor/slate-editor";
 
 // xxxJSON types correspond to [Classic] Slate 0.47 types
 type ElementJSON = BlockJSON | InlineJSON;
@@ -33,6 +32,12 @@ export interface SlateDocument {
   children: SlateNode[];
   // types map used for conversion back to Classic Slate (0.47)
   objTypes: ObjectTypeMap;
+}
+
+export interface SlateExchangeValue {
+  object: "value";
+  data?: { [key: string]: any };
+  document?: SlateDocument;
 }
 
 function typeProp(type?: string) {

--- a/src/slate-editor/slate-editor.tsx
+++ b/src/slate-editor/slate-editor.tsx
@@ -4,7 +4,6 @@ import { Plugin, Value } from "slate";
 import find from "lodash/find";
 import isEqual from "lodash/isEqual";
 import size from "lodash/size";
-import { SlateDocument, serializeValue } from "../serialization/serialization";
 import { HotkeyMap, useHotkeyMap } from "../common/slate-hooks";
 import { EditorValue, EFormat, textToSlate } from "../common/slate-types";
 import { ColorPlugin } from "../plugins/color-plugin";
@@ -33,7 +32,7 @@ export interface IProps {
   history?: boolean | IEditorHistoryOptions;
   onEditorRef?: (editorRef?: Editor) => void;
   onValueChange?: (value: EditorValue) => void;
-  onContentChange?: (content: SlateExchangeValue) => void;
+  onContentChange?: (value: EditorValue) => void;
   onFocus?: (editor?: Editor) => void;
   onBlur?: (editor?: Editor) => void;
   style?: React.CSSProperties;
@@ -46,12 +45,6 @@ const kDefaultHotkeyMap = {
         'mod+u': (editor: Editor) => editor.toggleMark(EFormat.underlined),
         'mod+\\': (editor: Editor) => editor.toggleMark(EFormat.code)
       };
-
-export interface SlateExchangeValue {
-  object: "value";
-  data?: { [key: string]: any };
-  document?: SlateDocument;
-}
 
 function extractUserDataJSON(value: Value) {
   const { data: _data } = value.toJSON({ preserveData: true });
@@ -90,7 +83,7 @@ const SlateEditor: React.FC<IProps> = (props: IProps) => {
                               isValueDataChange(change.value, prevValue);
     setPrevValue(change.value);
     onValueChange?.(change.value);
-    isContentChange && onContentChange?.(serializeValue(change.value));
+    isContentChange && onContentChange?.(change.value);
   }, [prevValue, onValueChange, onContentChange]);
 
   const hotkeyFnMap = useHotkeyMap(props.hotkeyMap || kDefaultHotkeyMap);


### PR DESCRIPTION
- Fix behavior of marks imported via HTML
- Pass a raw editor value to onContentChange() rather than a serialized value; client can choose serialization model

