### PR TITLE
Add onLoad callback

### DIFF
--- a/src/plugins/image-plugin.tsx
+++ b/src/plugins/image-plugin.tsx
@@ -13,6 +13,7 @@ const kImageHighlightClass = "cc-image-highlight";
 interface IRenderOptions {
   isSerializing?: boolean;
   isHighlighted?: boolean;
+  onLoad?: () => void;
   onClick?: () => void;
 }
 function renderImage(node: Inline, attributes: RenderAttributes, children: ReactNode, options?: IRenderOptions) {
@@ -20,9 +21,10 @@ function renderImage(node: Inline, attributes: RenderAttributes, children: React
   const highlightClass = options?.isHighlighted && !options?.isSerializing ? kImageHighlightClass : undefined;
   const classes = mergeClassStrings(highlightClass, attributes.className);
   const src: string = data.get("src");
+  const onLoad = options?.isSerializing ? undefined : options?.onLoad;
   const onClick = options?.isSerializing ? undefined : options?.onClick;
   return (
-    <img className={classes} src={src} onClick={onClick} {...attributes}/>
+    <img className={classes} src={src} onClick={onClick} onLoad={onLoad} {...attributes}/>
   );
 }
 
@@ -93,6 +95,7 @@ export function ImagePlugin(): HtmlSerializablePlugin {
       const options: IRenderOptions = {
               isSerializing: false,
               isHighlighted: props.isSelected || props.isFocused,
+              onLoad: () => editor.command("onLoad", node),
               onClick: () => editor.moveFocusToStartOfNode(node)
             };
       return renderImage(node, { ...dataAttrs, ...attributes }, children, options);

--- a/src/plugins/on-load-plugin.tsx
+++ b/src/plugins/on-load-plugin.tsx
@@ -1,0 +1,16 @@
+import { Editor, Plugin } from "slate-react";
+import { Node } from "slate";
+
+/*
+ * Calls its onLoad() argument when resources load (e.g. <img> onLoad).
+ */
+export function OnLoadPlugin(onLoad?: (node: Node) => void): Plugin {
+  return {
+    commands: {
+      onLoad: function (editor: Editor, node: Node) {
+        onLoad?.(node);
+        return editor;
+      }
+    }
+  };
+}


### PR DESCRIPTION
For the question-interactives, the size of the container `<div>` auto-sizes to fit the size of the content. This works fine for plain/rich text, because every change to the model results in an `onValueChange()` callback, at which point the client can measure the size of the content and react accordingly. Images don't work in this model, however, because `<img>` tags appear in the content before their image is actually loaded, and when the image does actually load it doesn't trigger an `onValueChange()` callback. Therefore, we add a new `onLoad()` callback which is triggered whenever a resource loads outside the context of a regular model change. Currently only `<img>` tags use it, but if we encounter any other nodes whose size can change asynchronously from model changes, they can make use of it as well. It turned out to be simple to implement the functionality using a Slate plugin.