### PR TITLE
Allow client to specify dialog `themeColor`

### DIFF
--- a/src/editor-toolbar/editor-toolbar.stories.js
+++ b/src/editor-toolbar/editor-toolbar.stories.js
@@ -74,7 +74,7 @@ export const Vertical = () => (
 export const Colored = () => (
   <EditorToolbar
     orientation="vertical"
-    colors={{ background: "#177991", fill: "#ffffff" }}
+    colors={{buttonColors: { background: "#177991", fill: "#ffffff" }}}
     iconSize={16}
     buttons={buttons}
     onDidInvokeTool={format => console.log("Tool invoked:", format)}

--- a/src/editor-toolbar/editor-toolbar.tsx
+++ b/src/editor-toolbar/editor-toolbar.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef } from "react";
-import { IBaseProps, IColors, OnDidInvokeToolFn, ToolbarButton } from "./toolbar-button";
+import { IBaseProps, IButtonColors, OnDidInvokeToolFn, ToolbarButton } from "./toolbar-button";
 import { Editor } from "slate-react";
 import { SelectionJSON } from "slate";
 
@@ -7,12 +7,17 @@ export interface IButtonSpec extends IBaseProps {
   iconSize?: number;
 }
 
+export interface IToolbarColors {
+  buttonColors?: IButtonColors;
+  selectedColors?: IButtonColors;
+  themeColor?: string;
+}
+
 export interface IProps {
   className?: string;
   orientation?: "horizontal" | "vertical";
   padding?: number;
-  colors?: IColors;
-  selectedColors?: IColors;
+  colors?: IToolbarColors;
   buttonsPerRow?: number;
   iconSize?: number;
   buttonSize?: number;
@@ -37,7 +42,7 @@ export function getPlatformTooltip(str: string) {
 
 export const EditorToolbar: React.FC<IProps> = (iProps: IProps) => {
   const props = { ...kDefaultProps, ...iProps } as Required<IProps>;
-  const { orientation, colors, selectedColors, buttonsPerRow, iconSize, buttonSize, buttons,
+  const { orientation, colors, buttonsPerRow, iconSize, buttonSize, buttons,
           onDidInvokeTool, padding, editor } = props;
   const longAxisButtonCount = buttonsPerRow || buttons.length;
   const crossAxisButtonCount = buttonsPerRow ? Math.ceil(buttons.length / buttonsPerRow) : 1;
@@ -47,8 +52,8 @@ export const EditorToolbar: React.FC<IProps> = (iProps: IProps) => {
   const toolbarSize = orientation === "vertical"
           ? { width: toolbarCrossExtent, height: toolbarLongExtent }
           : { width: toolbarLongExtent, height: toolbarCrossExtent };
-  const toolbarStyle = colors?.background
-                        ? { backgroundColor: colors.background, ...toolbarSize }
+  const toolbarStyle = colors?.buttonColors?.background
+                        ? { backgroundColor: colors.buttonColors.background, ...toolbarSize }
                         : toolbarSize;
   const orientationClass = orientation || "horizontal";
 
@@ -75,7 +80,7 @@ export const EditorToolbar: React.FC<IProps> = (iProps: IProps) => {
             const _iconSize = button.iconSize || iconSize;
             return (
               <ToolbarButton key={`key-${format}`} format={format} iconSize={_iconSize} buttonSize={buttonSize}
-                colors={colors} selectedColors={selectedColors} onDidInvokeTool={onDidInvokeTool}
+                colors={colors?.buttonColors} selectedColors={colors?.selectedColors} onDidInvokeTool={onDidInvokeTool}
                 onSaveSelection={handleSaveSelection} onRestoreSelection={handleRestoreSelection} {...others} />
             );
           })

--- a/src/editor-toolbar/toolbar-button.tsx
+++ b/src/editor-toolbar/toolbar-button.tsx
@@ -11,7 +11,7 @@ export type OnDidInvokeToolFn = (format: string) => void;
 const kDefaultFillColor = "#909090";
 const kDefaultSelectedFillColor = "#009CDC";
 
-export interface IColors {
+export interface IButtonColors {
   fill?: string;
   background?: string;
 }
@@ -19,8 +19,8 @@ export interface IColors {
 export interface IBaseProps {
   format: EFormat | EMetaFormat;
   SvgIcon: (props: IconProps) => JSX.Element;
-  colors?: IColors;
-  selectedColors?: IColors;
+  colors?: IButtonColors;
+  selectedColors?: IButtonColors;
   tooltip: string;
   isActive: boolean;
   isEnabled?: boolean;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,8 +10,8 @@ export { SlateEditor } from "./slate-editor/slate-editor";
 export { getContentHeight } from "./slate-editor/slate-utils";
 export { DisplayDialogFunction, DisplayDialogSettings, IToolOrder, OrderEntry, SlateToolbar
         } from "./slate-toolbar/slate-toolbar";
-export { EditorToolbar, IButtonSpec, getPlatformTooltip } from "./editor-toolbar/editor-toolbar";
-export { IColors, OnChangeColorFn, OnChangeFn, OnClickFn, OnDidInvokeToolFn, OnMouseFn, ToolbarButton
+export { EditorToolbar, IButtonSpec, IToolbarColors, getPlatformTooltip } from "./editor-toolbar/editor-toolbar";
+export { OnChangeColorFn, OnChangeFn, OnClickFn, OnDidInvokeToolFn, OnMouseFn, ToolbarButton
         } from "./editor-toolbar/toolbar-button";
 import "./slate-container/slate-container.scss";
 import "./slate-editor/slate-editor.scss";

--- a/src/slate-container/slate-container.stories.js
+++ b/src/slate-container/slate-container.stories.js
@@ -20,8 +20,10 @@ export const ColoredToolbarSelectedFill = () => {
   const [value, setValue] = useState(coloredText);
   return (
     <SlateContainer value={value} onValueChange={_value => setValue(_value)}
-    toolbar={{ colors: { fill: "#ffffff", background: "#177991" },
-                selectedColors: { fill: "#72bfca", background: "#177991" } }} />
+      toolbar={{ colors: {
+                  buttonColors: { fill: "#ffffff", background: "#177991" },
+                  selectedColors: { fill: "#72bfca", background: "#177991" }
+              }}} />
   );
 };
 
@@ -31,8 +33,38 @@ export const ColoredToolbarSelectedBackground = () => {
   const [value, setValue] = useState(backgroundText);
   return (
     <SlateContainer value={value} onValueChange={_value => setValue(_value)}
-    toolbar={{ colors: { fill: "#ffffff", background: "#177991" },
-                selectedColors: { fill: "#177991", background: "#72bfca" } }} />
+      toolbar={{ colors: {
+                  buttonColors: { fill: "#ffffff", background: "#177991" },
+                  selectedColors: { fill: "#177991", background: "#72bfca" }
+              }}} />
+  );
+};
+
+const themeColorText = "This example demonstrates a toolbar with black icons on a white background.";
+
+export const BlackOnWhiteToolbar = () => {
+  const [value, setValue] = useState(themeColorText);
+  return (
+    <SlateContainer value={value} onValueChange={_value => setValue(_value)}
+      toolbar={{ colors: {
+                  buttonColors: { fill: "#000000", background: "#ffffff" },
+                  selectedColors: { fill: "#ffffff", background: "#000000" },
+                  themeColor: "#177991"
+              }}} />
+  );
+};
+
+const themeColorText2 = "This example demonstrates a toolbar with white icons on a black background.";
+
+export const WhiteOnBlackToolbar = () => {
+  const [value, setValue] = useState(themeColorText2);
+  return (
+    <SlateContainer value={value} onValueChange={_value => setValue(_value)}
+      toolbar={{ colors: {
+                  buttonColors: { fill: "#ffffff", background: "#000000" },
+                  selectedColors: { fill: "#000000", background: "#ffffff" },
+                  themeColor: "#177991"
+              }}} />
   );
 };
 

--- a/src/slate-toolbar/slate-dialog.stories.js
+++ b/src/slate-toolbar/slate-dialog.stories.js
@@ -32,6 +32,8 @@ export const ColoredModalDialog = () => {
   const [value, setValue] = useState(coloredModalText);
   return (
     <SlateContainer value={value} onValueChange={_value => setValue(_value)}
-                    toolbar={{ colors: { fill: "#ffffff", background: "#FF7FB6" }}} />
+                    toolbar={{ colors: {
+                                buttonColors: { fill: "#ffffff", background: "#FF7FB6" }
+                            }}} />
   );
 };

--- a/src/slate-toolbar/slate-toolbar.tsx
+++ b/src/slate-toolbar/slate-toolbar.tsx
@@ -127,8 +127,8 @@ export const SlateToolbar: React.FC<IProps> = (props: IProps) => {
       return {
         format: EFormat.color,
         SvgIcon: InputColor,
-        colors: { ...props.colors, fill },
-        selectedColors: { ...props.selectedColors, fill },
+        colors: { ...props.colors?.buttonColors, fill },
+        selectedColors: { ...props.colors?.selectedColors, fill },
         tooltip: getPlatformTooltip("color"),
         isActive: !!editor && editor.query("hasActiveColorMark"),
         onMouseDown: () => {
@@ -272,13 +272,14 @@ export const SlateToolbar: React.FC<IProps> = (props: IProps) => {
     editor && inputs && dialogSettings?.onAccept?.(editor, inputs);
   };
 
+  const themeColor = props.colors?.themeColor || props.colors?.buttonColors?.background;
   const dialog = showDialog && dialogSettings
                   ? (props.modalPortalRoot
                       ? <ModalDialogPortal
                           modalPortalRoot={props.modalPortalRoot}
                           coverClassName={props.modalCoverClassName}
                           dialogClassName={props.modalDialogClassName}
-                          themeColor={props.colors?.background}
+                          themeColor={themeColor}
                           title={dialogSettings.title}
                           prompts={dialogSettings.prompts}
                           onClose={handleCloseDialog}
@@ -286,7 +287,7 @@ export const SlateToolbar: React.FC<IProps> = (props: IProps) => {
                       : <ModalDialog
                           coverClassName={props.modalCoverClassName}
                           dialogClassName={props.modalDialogClassName}
-                          themeColor={props.colors?.background}
+                          themeColor={themeColor}
                           title={dialogSettings.title}
                           prompts={dialogSettings.prompts}
                           onClose={handleCloseDialog}


### PR DESCRIPTION
Allow client to specify dialog `themeColor` rather than assuming it's the toolbar background color.

Provides means to fix `question-interactives` authoring bug in which toolbar background color is white, resulting in white-on-white text.