### PR TITLE
Use `@concord-consortium/slate-react` instead of `slate-react`

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = async ({ config, mode }) => {
       presets: [['react-app', { flow: false, typescript: true }]],
     },
   });
+  config.resolve.alias['slate-react'] = '@concord-consortium/slate-react';
   config.resolve.extensions.push('.ts', '.tsx');
 
   return config;

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,8 @@ module.exports = {
   },
   testMatch: ["**/*.test.(ts|tsx)"],
   moduleNameMapper: {
+    // map slate-react to our published fork
+    "^slate-react$": "@concord-consortium/slate-react",
     // Mocks out all these file formats when tests are run
     "\\.(jpg|ico|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
       "identity-obj-proxy",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1874,6 +1874,44 @@
         "minimist": "^1.2.0"
       }
     },
+    "@concord-consortium/slate-react": {
+      "version": "0.22.10-cc.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-react/-/slate-react-0.22.10-cc.1.tgz",
+      "integrity": "sha512-AHwJcenPPhZOmVtW6qLrJrHeMHwyPaHjgQSKtxrSyyh4pj53lvKexivVnkpEFGBjpK3CYT49Mb/FKaW4HDVXuQ==",
+      "requires": {
+        "debug": "^3.1.0",
+        "get-window": "^1.1.1",
+        "is-window": "^1.0.2",
+        "lodash": "^4.1.1",
+        "memoize-one": "^4.0.0",
+        "prop-types": "^15.5.8",
+        "react-immutable-proptypes": "^2.1.0",
+        "selection-is-backward": "^1.0.0",
+        "slate-base64-serializer": "^0.2.112",
+        "slate-dev-environment": "^0.2.2",
+        "slate-hotkeys": "^0.2.9",
+        "slate-plain-serializer": "^0.7.11",
+        "slate-prop-types": "^0.5.42",
+        "slate-react-placeholder": "^0.2.9",
+        "tiny-invariant": "^1.0.1",
+        "tiny-warning": "^0.0.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "@emotion/cache": {
       "version": "10.0.29",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
@@ -2559,6 +2597,15 @@
         "invariant": "^2.2.3",
         "prop-types": "^15.6.1",
         "react-lifecycles-compat": "^3.0.4"
+      }
+    },
+    "@rollup/plugin-alias": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-3.1.1.tgz",
+      "integrity": "sha512-hNcQY4bpBUIvxekd26DBPgF7BT4mKVNDF5tBG4Zi+3IgwLxGYRY0itHs9D0oLVwXM5pvJDWJlBQro+au8WaUWw==",
+      "dev": true,
+      "requires": {
+        "slash": "^3.0.0"
       }
     },
     "@rollup/plugin-commonjs": {
@@ -16950,25 +16997,25 @@
       }
     },
     "slate-base64-serializer": {
-      "version": "0.2.112",
-      "resolved": "https://registry.npmjs.org/slate-base64-serializer/-/slate-base64-serializer-0.2.112.tgz",
-      "integrity": "sha512-Vo94bkCq8cbFj7Lutdh2RaM9S4WlLxnnMqZPKGUyefklUN4q2EzM/WUH7s9CIlLUH1qRfC/b0V25VJZr5XXTzA==",
+      "version": "0.2.115",
+      "resolved": "https://registry.npmjs.org/slate-base64-serializer/-/slate-base64-serializer-0.2.115.tgz",
+      "integrity": "sha512-GnLV7bUW/UQ5j7rVIxCU5zdB6NOVsEU6YWsCp68dndIjSGTGLaQv2+WwV3NcnrGGZEYe5qgo33j2QWrPws2C1A==",
       "requires": {
         "isomorphic-base64": "^1.0.2"
       }
     },
     "slate-dev-environment": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/slate-dev-environment/-/slate-dev-environment-0.2.2.tgz",
-      "integrity": "sha512-JZ09llrRQu6JUsLJCUlGC0lB1r1qIAabAkSd454iyYBq6lDuY//Bypi3Jo8yzIfzZ4+mRLdQvl9e8MbeM9l48Q==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/slate-dev-environment/-/slate-dev-environment-0.2.5.tgz",
+      "integrity": "sha512-oLD8Fclv/RqrDv6RYfN2CRzNcRXsUB99Qgcw5L/njTjxAdDPguV6edQ3DgUG9Q2pLFLhI15DwsKClzVfFzfwGQ==",
       "requires": {
         "is-in-browser": "^1.1.3"
       }
     },
     "slate-hotkeys": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/slate-hotkeys/-/slate-hotkeys-0.2.9.tgz",
-      "integrity": "sha512-y+C/s5vJEmBxo8fIqHmUcdViGwALL/A6Qow3sNG1OHYD5SI11tC2gfYtGbPh+2q0H7O4lufffCmFsP5bMaDHqA==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/slate-hotkeys/-/slate-hotkeys-0.2.11.tgz",
+      "integrity": "sha512-xhq/TlI74dRbO57O4ulGsvCcV4eaQ5nEEz9noZjeNLtNzFRd6lSgExRqAJqKGGIeJw+FnJ3OcqGvdb5CEc9/Ew==",
       "requires": {
         "is-hotkey": "0.1.4",
         "slate-dev-environment": "^0.2.2"
@@ -16995,47 +17042,9 @@
       "integrity": "sha512-TtrlaslxQBEMV0LYdf3s7VAbTxRPe1xaW10WNNGAzGA855/0RhkaHjKkQiRjHv5rvbRleVf7Nxr9fH+4uErfxQ=="
     },
     "slate-prop-types": {
-      "version": "0.5.42",
-      "resolved": "https://registry.npmjs.org/slate-prop-types/-/slate-prop-types-0.5.42.tgz",
-      "integrity": "sha512-3n3556FDs9/cyhRdDMryVB1PJvWeu+p3dx9TvHtONybud4tfulWk4r175JoVWcFZCUFGFQK7IbObUbz1MWNKCg=="
-    },
-    "slate-react": {
-      "version": "0.22.10",
-      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.22.10.tgz",
-      "integrity": "sha512-B2Ms1u/REbdd8yKkOItKgrw/tX8klgz5l5x6PP86+oh/yqmB6EHe0QyrYlQ9fc3WBlJUVTOL+nyAP1KmlKj2/w==",
-      "requires": {
-        "debug": "^3.1.0",
-        "get-window": "^1.1.1",
-        "is-window": "^1.0.2",
-        "lodash": "^4.1.1",
-        "memoize-one": "^4.0.0",
-        "prop-types": "^15.5.8",
-        "react-immutable-proptypes": "^2.1.0",
-        "selection-is-backward": "^1.0.0",
-        "slate-base64-serializer": "^0.2.112",
-        "slate-dev-environment": "^0.2.2",
-        "slate-hotkeys": "^0.2.9",
-        "slate-plain-serializer": "^0.7.11",
-        "slate-prop-types": "^0.5.42",
-        "slate-react-placeholder": "^0.2.9",
-        "tiny-invariant": "^1.0.1",
-        "tiny-warning": "^0.0.3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
+      "version": "0.5.44",
+      "resolved": "https://registry.npmjs.org/slate-prop-types/-/slate-prop-types-0.5.44.tgz",
+      "integrity": "sha512-JS0iW7uaciE/W3ADuzeN1HOnSjncQhHPXJ65nZNQzB0DF7mXVmbwQKI6cmCo/xKni7XRJT0JbWSpXFhEdPiBUA=="
     },
     "slate-react-placeholder": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.10.3",
+    "@rollup/plugin-alias": "^3.1.1",
     "@rollup/plugin-commonjs": "^12.0.0",
     "@rollup/plugin-node-resolve": "^8.1.0",
     "@storybook/addon-actions": "^5.3.19",
@@ -82,6 +83,7 @@
     "typescript": "^3.9.5"
   },
   "dependencies": {
+    "@concord-consortium/slate-react": "^0.22.10-cc.1",
     "classnames": "^2.2.6",
     "immutable": "^3.8.2",
     "is-hotkey": "^0.1.6",
@@ -89,7 +91,6 @@
     "slate": "^0.47.9",
     "slate-html-serializer": "^0.8.13",
     "slate-plain-serializer": "^0.7.13",
-    "slate-react": "^0.22.10",
     "style-to-object": "^0.3.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,13 +1,9 @@
+import alias from "@rollup/plugin-alias";
 import external from "rollup-plugin-peer-deps-external";
 import resolve from "@rollup/plugin-node-resolve";
 import typescript from "rollup-plugin-typescript2";
 import commonjs from "@rollup/plugin-commonjs";
 import sass from "rollup-plugin-sass";
-
-import * as esrever from "esrever";
-import * as immutable from "immutable";
-import * as React from "react";
-import * as ReactDOM from "react-dom";
 
 import packageJson from "./package.json";
 
@@ -26,6 +22,11 @@ export default {
     }
   ],
   plugins: [
+    alias({
+      entries: [
+        { find: 'slate-react', replacement: '@concord-consortium/slate-react' }
+      ]
+    }),
     external(),
     resolve({
       browser: true


### PR DESCRIPTION
Primarily includes several IME fixes to enable Chinese/Japanese/etc. input. See [[#173260782]](https://www.pivotaltracker.com/story/show/173260782) for details.

See [@cc/slate #1](https://github.com/concord-consortium/slate/pull/1) and [@cc/slate #2](https://github.com/concord-consortium/slate/pull/2) for details of the underlying fixes.

Most of the changes in this PR relate to aliasing `slate-react` to `@concord-consortium/slate-react` so that client code doesn't need to change.