### PR TITLE
Auto-scroll to selection after toolbar invocation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1862,9 +1862,9 @@
       }
     },
     "@concord-consortium/slate-react": {
-      "version": "0.22.10-cc.2",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-react/-/slate-react-0.22.10-cc.2.tgz",
-      "integrity": "sha512-nvNg8NSN63TvHisgufTRaIiejJ8AlhrBBjr3BsAKDWdFzQDX4NRJD1nrEYvevJp/KOV1rDD8UMSFT07QS2MpNQ==",
+      "version": "0.22.10-cc.3",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-react/-/slate-react-0.22.10-cc.3.tgz",
+      "integrity": "sha512-wYGAHZf62ygpPlgHXvXWCg/waf59ZHoFoeAvC/7A9v5qJcMPaL1QkCIsdGJXTKqSK+GMdwttNAix0A2ECDe0xg==",
       "requires": {
         "debug": "^3.1.0",
         "get-window": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "typescript": "^3.9.7"
   },
   "dependencies": {
-    "@concord-consortium/slate-react": "^0.22.10-cc.2",
+    "@concord-consortium/slate-react": "^0.22.10-cc.3",
     "classnames": "^2.2.6",
     "immutable": "^3.8.2",
     "is-hotkey": "^0.1.6",

--- a/src/editor-toolbar/editor-toolbar.tsx
+++ b/src/editor-toolbar/editor-toolbar.tsx
@@ -68,6 +68,9 @@ export const EditorToolbar: React.FC<IProps> = (iProps: IProps) => {
   const handleRestoreSelection = useCallback(() => {
     editor && editor.select(savedSelection.current);
   }, [editor]);
+  const handleUserActionPerformed = useCallback(() => {
+    editor && editor.command("setUserActionPerformed");
+  }, [editor]);
 
   if (iProps.show === false) return null;
 
@@ -81,7 +84,8 @@ export const EditorToolbar: React.FC<IProps> = (iProps: IProps) => {
             return (
               <ToolbarButton key={`key-${format}`} format={format} iconSize={_iconSize} buttonSize={buttonSize}
                 colors={colors?.buttonColors} selectedColors={colors?.selectedColors} onDidInvokeTool={onDidInvokeTool}
-                onSaveSelection={handleSaveSelection} onRestoreSelection={handleRestoreSelection} {...others} />
+                onSaveSelection={handleSaveSelection} onRestoreSelection={handleRestoreSelection}
+                onUserActionPerformed={handleUserActionPerformed} {...others} />
             );
           })
         }

--- a/src/editor-toolbar/toolbar-button.tsx
+++ b/src/editor-toolbar/toolbar-button.tsx
@@ -30,14 +30,15 @@ export interface IBaseProps {
   onDidInvokeTool?: OnDidInvokeToolFn;
   onSaveSelection?: () => void;
   onRestoreSelection?: () => void;
+  onUserActionPerformed?: () => void;
 }
 export interface IProps extends IBaseProps {
   iconSize: number;
   buttonSize: number;
 }
 export const ToolbarButton: React.FC<IProps> = (props: IProps) => {
-  const { format, SvgIcon, iconSize, buttonSize, tooltip, isActive, isEnabled, colors, selectedColors,
-          onChange, onClick, onMouseDown, onDidInvokeTool, onSaveSelection, onRestoreSelection } = props;
+  const { format, SvgIcon, iconSize, buttonSize, tooltip, isActive, isEnabled, colors, selectedColors, onChange,
+          onClick, onMouseDown, onDidInvokeTool, onSaveSelection, onRestoreSelection, onUserActionPerformed } = props;
   const buttonStyle: CSSProperties = {
           width: buttonSize,
           height: buttonSize
@@ -57,10 +58,12 @@ export const ToolbarButton: React.FC<IProps> = (props: IProps) => {
   }
   const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
     onSaveSelection?.();
+    onUserActionPerformed?.();
     onMouseDown?.(e);
   };
   const handleEnabledClick = (e: React.MouseEvent<HTMLDivElement>) => {
     onRestoreSelection?.();
+    onUserActionPerformed?.();
     if (onClick) {
       onClick(format, e);
       onDidInvokeTool?.(props.format);


### PR DESCRIPTION
Calls `setUserActionPerformed()` on toolbar clicks, which triggers auto-scroll to the selection on the next render.