### PR TITLE
Fix bugs editing some content imported as HTML

### DIFF
--- a/src/plugins/core-blocks-plugin.tsx
+++ b/src/plugins/core-blocks-plugin.tsx
@@ -47,7 +47,8 @@ kLegacyBlockTags.forEach(tag => kTagToFormatMap[tag] = EFormat.block);
 export function getTagForBlock(node: Node) {
   if (!Block.isBlock(node)) return undefined;
   const { type: format, data } = node;
-  return data.get("tag") || kFormatToTagMap[format];
+  // only use the imported tag for generic <div> elements
+  return (node.type === EFormat.block ? data.get("tag") : "") || kFormatToTagMap[format];
 }
 
 function getDataFromBlockElement(el: Element) {
@@ -101,7 +102,7 @@ export function CoreBlocksPlugin(): HtmlSerializablePlugin {
         return renderBlockAsTag(tag, node, attributes, children, true);
       }
     },
-  
+
     onCommand(command, editor, next) {
       const { type, args } = command;
       if (type === "toggleBlock") {

--- a/src/serialization/serialization.stories.tsx
+++ b/src/serialization/serialization.stories.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import pretty from "pretty";
 import { SlateContainer } from "../slate-container/slate-container";
 import { textToSlate } from "../common/slate-types";
-import { slateToHtml } from "./html-serializer";
+import { slateToHtml, htmlToSlate } from "./html-serializer";
 import { serializeSelection, serializeValue } from "./serialization";
 import "./serialization.stories.scss";
 
@@ -59,6 +59,31 @@ const htmlSerializationText = "This example shows the editor content serialized 
 
 export const HtmlSerialization = () => {
   const slateValue = textToSlate(htmlSerializationText);
+  const [value, setValue] = useState(slateValue);
+  const [content, setContent] = useState(slateToHtml(value));
+  return (
+    <div className="serialization-container">
+      <div className="panel">
+        <SlateContainer
+          value={value}
+          onValueChange={_value => {
+            setValue(_value);
+            setContent(slateToHtml(_value));
+          }}
+        />
+      </div>
+      <div className="panel output">
+        <h3>Serialized HTML</h3>
+        <pre>{pretty(content)}</pre>
+      </div>
+    </div>
+  );
+};
+
+const importedHtmlText = "<h1>A header paragraph</h1><p>A simple paragraph.</p><blockquote>A quoted paragraph.</blockquote>";
+
+export const ImportedHTML = () => {
+  const slateValue = htmlToSlate(importedHtmlText);
   const [value, setValue] = useState(slateValue);
   const [content, setContent] = useState(slateToHtml(value));
   return (


### PR DESCRIPTION
[[#173991240]](https://www.pivotaltracker.com/story/show/173991240) [[#173991084]](https://www.pivotaltracker.com/story/show/173991084)

When importing HTML, we track the tag that was originally imported because in some cases it can be used to re-export the HTML with higher fidelity. For instance, there are some block-level tags that occur in LARA content but that are not explicitly supported by `slate-editor` (e.g. `<fieldset>`). For these blocks, we convert them to a generic `<div>` internally but we also remember the imported tag. On export then, we can write out the original tag, thus preserving the fidelity of the original import. Much of the HTML import/export code was tested by importing and then immediately exporting HTML content and verifying that the fidelity of the original import was maintained.

It turns out that preserving the originally imported tag is not necessarily desirable when actually editing content, however. Once the user has edited a node, for instance converting a simple paragraph (`<p>`) to a block quote (`<blockquote>`), it is no longer appropriate to use the originally imported tag on export, as this results in simply ignoring the user's edits. 🤦 Further consideration reveals that the only time we should prefer the originally imported tag is when we are exporting a generic `<div>` node.

This PR includes a storybook story which allows for testing the editing of imported HTML. Unfortunately, if you run it on the branch, it should just work because the branch also contains the fix. To see the buggy behavior, you can locally checkout the first commit of this PR (which implements the story) but does not include the fix.