### PR TITLE
Release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Version 0.7.0 - February 11, 2021
+
+- Support `placeholder` editor prop
+- Support `readOnly` editor prop
+- `<a>` tags specify `target="_blank"` by default
+- Export additional TypeScript types (`EditorRange`, `EFormat`, etc.)
+- Update dependencies
+
 ## Version 0.6.0 - August 26, 2020
 
 - Fix bug which prevented editing of some blocks imported from HTML

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/slate-editor",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/slate-editor",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Slate-based rich text editor component for use in CC projects",
   "main": "build/index.js",
   "module": "build/index.esm.js",


### PR DESCRIPTION
## Version 0.7.0 - February 11, 2021

- Support `placeholder` editor prop
- Support `readOnly` editor prop
- `<a>` tags specify `target="_blank"` by default
- Export additional TypeScript types (`EditorRange`, `EFormat`, etc.)
- Update dependencies