### PR TITLE
Support validation of dialog contents; validate user-entered urls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10794,6 +10794,12 @@
       "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
       "dev": true
     },
+    "@types/valid-url": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/valid-url/-/valid-url-1.0.3.tgz",
+      "integrity": "sha512-+33x29mg+ecU88ODdWpqaie2upIuRkhujVLA7TuJjM823cNMbeggfI6NhxewaRaRF8dy+g33e4uIg/m5Mb3xDQ==",
+      "dev": true
+    },
     "@types/webpack": {
       "version": "4.41.26",
       "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.26.tgz",
@@ -28944,6 +28950,11 @@
           "dev": true
         }
       }
+    },
+    "valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@types/slate-html-serializer": "^0.6.4",
     "@types/slate-plain-serializer": "^0.7.0",
     "@types/slate-react": "^0.22.9",
+    "@types/valid-url": "^1.0.3",
     "@typescript-eslint/eslint-plugin": "^4.15.0",
     "@typescript-eslint/parser": "^4.15.0",
     "babel-loader": "^8.2.2",
@@ -99,6 +100,7 @@
     "slate": "^0.47.9",
     "slate-html-serializer": "^0.8.13",
     "slate-plain-serializer": "^0.7.13",
-    "style-to-object": "^0.3.0"
+    "style-to-object": "^0.3.0",
+    "valid-url": "^1.0.9"
   }
 }

--- a/src/plugins/image-plugin.tsx
+++ b/src/plugins/image-plugin.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from "react";
 import classNames from "classnames/dedupe";
 import clone from "lodash/clone";
+import { isWebUri } from "valid-url";
 import { Inline } from "slate";
 import { Editor, RenderAttributes, RenderInlineProps } from "slate-react";
 import { EFormat } from "../common/slate-types";
@@ -201,6 +202,7 @@ export function ImagePlugin(): HtmlSerializablePlugin {
               }
             }
           },
+          onValidate: (values) => isWebUri(values.source) ? values : "Error: please enter a properly formatted url",
           onAccept: (_editor, values) => _editor.command("addImage", values, node)
         });
         return editor;
@@ -213,7 +215,7 @@ export function ImagePlugin(): HtmlSerializablePlugin {
                       : undefined;
         const w = Math.round(parseFloat(width));
         const h = Math.round(parseFloat(height));
-        const size = w & h
+        const size = w && h
                       ? { width: w, height: h }
                       : undefined;
         const _constrain = constrain === "false"

--- a/src/plugins/link-plugin.tsx
+++ b/src/plugins/link-plugin.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from "react";
 import { Inline } from "slate";
 import { Editor, RenderAttributes, RenderInlineProps } from "slate-react";
+import { isWebUri } from "valid-url";
 import { EFormat } from "../common/slate-types";
 import { getRenderAttributesFromNode, getDataFromElement } from "../serialization/html-utils";
 import { hasActiveInline } from "../slate-editor/slate-utils";
@@ -89,6 +90,7 @@ export function LinkPlugin(): HtmlSerializablePlugin {
             title: "Insert Link",
             rows: [...textField, ...urlField],
             values: {},
+            onValidate: (values) => isWebUri(values.linkUrl) ? values : "Error: please enter a properly formatted url",
             onAccept: (_editor, inputs) => _editor.command(linkCmd, inputs)
           });
         }

--- a/src/slate-toolbar/modal-dialog.tsx
+++ b/src/slate-toolbar/modal-dialog.tsx
@@ -32,11 +32,13 @@ export interface IProps {
   fieldValues: IFieldValues;
   onSetValue: (name: string, value: string, type: FieldType) => void;
   onChange?: (name: string, value: string, type: FieldType) => void;
+  // string indicates error message
+  onValidate?: (values: IFieldValues) => IFieldValues | string;
   onClose: (values?: IFieldValues) => void;
 }
 
 export const ModalDialog: React.FC<IProps> = (props) => {
-  const { themeColor, fontColor, title, rows, fieldValues, onSetValue, onChange, onClose } = props;
+  const { themeColor, fontColor, title, rows, fieldValues, onSetValue, onChange, onValidate, onClose } = props;
 
   // CSS styles
   const themeStyle = themeColor ? {backgroundColor: `${themeColor}`} : undefined;
@@ -74,7 +76,13 @@ export const ModalDialog: React.FC<IProps> = (props) => {
     onClose();
   };
   const handleOkClick = () => {
-    onClose(fieldValues);
+    const validated = onValidate ? onValidate(fieldValues) : fieldValues;
+    if (typeof validated === "string") {
+      alert(validated);
+    }
+    else {
+      onClose(validated);
+    }
   };
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (!isMenuOpen) {

--- a/src/slate-toolbar/slate-toolbar.tsx
+++ b/src/slate-toolbar/slate-toolbar.tsx
@@ -51,6 +51,7 @@ export interface DisplayDialogSettings {
   rows: IRow[];
   values: IFieldValues;
   onChange?: (editor: Editor, name: string, value: string, values: IFieldValues) => boolean | undefined;
+  onValidate?: (values: IFieldValues) => IFieldValues | string;
   onAccept?: (editor: Editor, values: IFieldValues) => void;
 }
 
@@ -337,6 +338,7 @@ export const SlateToolbar: React.FC<IProps> = (props: IProps) => {
                           fieldValues={settingsRef.current.values}
                           onSetValue={handleSetValue}
                           onChange={handleChange}
+                          onValidate={settingsRef.current.onValidate}
                           onClose={handleClose}
                         />
                       : <ModalDialog
@@ -348,6 +350,7 @@ export const SlateToolbar: React.FC<IProps> = (props: IProps) => {
                           fieldValues={settingsRef.current.values}
                           onSetValue={handleSetValue}
                           onChange={handleChange}
+                          onValidate={settingsRef.current.onValidate}
                           onClose={handleClose}
                         />)
                   : null;


### PR DESCRIPTION
use it to validate user-entered urls for images and links in dialogs

This was suggested by a comment of @lbondaryk's.

Note that our dialog implementation now has two separate notions of validation, one that occurs in `onChange` and one that occurs when the ok button is clicked. There may be a way to unify them at some point but I don't think that day is today.