### PR TITLE
Handle/ignore `className` property which confuses React

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,9 @@ export { EditorContent, EditorRange, EditorValue, EFormat, slateToText, textToSl
 export { HtmlSerializablePlugin } from "./plugins/html-serializable-plugin";
 export { htmlToSlate, slateToHtml } from "./serialization/html-serializer";
 export {
+  deserializeValueFromLegacy, serializeValueToLegacy, validateNodeData
+} from "./serialization/legacy-serialization";
+export {
   deserializeDocument, deserializeValue, serializeDocument, serializeValue, SlateDocument, SlateExchangeValue
 } from "./serialization/serialization";
 export { SlateContainer } from "./slate-container/slate-container";

--- a/src/serialization/html-serializer.test.tsx
+++ b/src/serialization/html-serializer.test.tsx
@@ -53,6 +53,12 @@ describe("htmlToSlate(), slateToHtml()", () => {
     ].forEach(html => expect(slateToHtml(htmlToSlate(html))).toBe(html));
   });
 
+  it("converts className attribute to class", () => {
+    [
+      `<ul className="foo"><li className="bar"></li></ul>`
+    ].forEach(html => expect(slateToHtml(htmlToSlate(html))).toBe(html.replace(/className/g, "class")));
+  });
+
   it("preserves invalid inline styles", () => {
     [
       `<p style="invalid:style">paragraph with invalid inline style</p>`

--- a/src/serialization/html-serializer.tsx
+++ b/src/serialization/html-serializer.tsx
@@ -25,7 +25,7 @@ const TEXT_RULE: HtmlSerializationRule = {
     }
 
     if (el.nodeName === '#text') {
-      if (el.nodeValue && el.nodeValue.match(/<!--.*?-->/)) return;
+      if (el.nodeValue?.match(/<!--.*?-->/)) return;
 
       return {
         object: 'text',

--- a/src/serialization/html-utils.test.ts
+++ b/src/serialization/html-utils.test.ts
@@ -1,0 +1,25 @@
+import { mergeClassStrings, toReactStyle } from "./html-utils";
+
+describe("HTML utility functions", () => {
+
+  describe("toReactStyle", () => {
+    it("returns undefined if there are no properties", () => {
+      expect(toReactStyle("")).toBeUndefined();
+    });
+    it("camelizes property names", () => {
+      expect(toReactStyle("background-color:white")).toEqual({ backgroundColor: "white" });
+    });
+    it("handles custom CSS properties without camelizing", () => {
+      expect(toReactStyle("--my-custom-color:white")).toEqual({ "--my-custom-color": "white" });
+    });
+  });
+
+  it("mergeClassStrings works as expected", () => {
+    expect(mergeClassStrings()).toBeUndefined();
+    expect(mergeClassStrings("", "")).toBeUndefined();
+    expect(mergeClassStrings("foo")).toBe("foo");
+    expect(mergeClassStrings("", "foo")).toBe("foo");
+    expect(mergeClassStrings("foo", "bar")).toBe("foo bar");
+    expect(mergeClassStrings("foo bar", "bar foo baz")).toBe("foo bar baz");
+  });
+});

--- a/src/serialization/html-utils.ts
+++ b/src/serialization/html-utils.ts
@@ -32,7 +32,8 @@ export function getDataFromElement(el: Element, _data?: Record<string, string>) 
   if (!el.hasAttributes()) return { data: _data };
   const data: Record<string, string> = _data || {};
   for (let i = 0; i < el.attributes.length; ++i) {
-    const key = el.attributes[i].name.toLowerCase();
+    let key = el.attributes[i].name.toLowerCase();
+    if (key === "classname") key = "class";
     data[key] = el.attributes[i].value;
   }
   return { data };
@@ -43,7 +44,7 @@ export function getRenderAttributesFromNode(obj: Block | Inline | Mark, omitProp
   const renderAttrs: Record<string, string | React.CSSProperties> = {};
   data.forEach((value, key: string) => {
     const _key = toReactAttributeKey(key);
-    if (!omitProps || !omitProps?.find(prop => prop === _key)) {
+    if (!omitProps?.find(prop => prop === _key)) {
       renderAttrs[_key] = _key === "style"
                             ? toReactStyle(value)
                             : value;

--- a/src/serialization/legacy-serialization.test.ts
+++ b/src/serialization/legacy-serialization.test.ts
@@ -1,0 +1,62 @@
+import { ValueJSON } from "slate";
+import { textToSlate } from "..";
+import { deserializeValueFromLegacy, serializeValueToLegacy } from "./legacy-serialization";
+
+const emptyJson: ValueJSON = {
+              object: "value",
+              document: {
+                "object": "document",
+                data: {},
+                nodes: [{
+                  object: "block",
+                  type: "paragraph",
+                  data: {},
+                  nodes: [{
+                    object: "text",
+                    text: "",
+                    marks: []
+                  }]
+                }]
+              }
+            };
+const emptyJSONStr = JSON.stringify(emptyJson);
+
+const emptyLegacyJson = serializeValueToLegacy(textToSlate(""));
+
+// due to prior import bugs, we sometimes encounter "className" properties
+const emptyJsonWithClassName: ValueJSON = {
+              object: "value",
+              document: {
+                "object": "document",
+                data: {},
+                nodes: [{
+                  object: "block",
+                  type: "paragraph",
+                  data: {
+                    className: null
+                  },
+                  nodes: [{
+                    object: "text",
+                    text: "",
+                    marks: []
+                  }]
+                }]
+              }
+            };
+const emptyJsonWithClassNameStr = JSON.stringify(emptyJsonWithClassName);
+
+describe("legacy serialization", () => {
+  it("de/serializes empty strings", () => {
+    expect(serializeValueToLegacy(textToSlate(""))).toBe(emptyJSONStr);
+    expect(serializeValueToLegacy(deserializeValueFromLegacy(emptyJSONStr))).toBe(emptyJSONStr);
+  });
+
+  it("converts invalid JSON to empty strings", () => {
+    expect(serializeValueToLegacy(deserializeValueFromLegacy(null as any))).toBe(emptyLegacyJson);
+    expect(serializeValueToLegacy(deserializeValueFromLegacy("}"))).toBe(emptyLegacyJson);
+  });
+
+  it("strips invalid 'className' properties", () => {
+    expect(serializeValueToLegacy(deserializeValueFromLegacy(emptyJsonWithClassNameStr))).toBe(emptyLegacyJson);
+  });
+});

--- a/src/serialization/legacy-serialization.ts
+++ b/src/serialization/legacy-serialization.ts
@@ -1,0 +1,33 @@
+import { Value } from "slate";
+import { textToSlate } from "../common/slate-types";
+
+export function deserializeValueFromLegacy(text: string) {
+  const parsed = safeJsonParse(text);
+  validateNodeData(parsed?.document);
+  return parsed
+          ? Value.fromJSON(parsed)
+          : textToSlate("");
+}
+
+export function serializeValueToLegacy(value: Value) {
+  return JSON.stringify(value.toJSON());
+}
+
+export function validateNodeData(node: any) {
+  // strip invalid "className" which can result from prior import/export bugs
+  if (node?.data && ("className" in node.data)) {
+    delete node.data.className;
+  }
+  node?.nodes?.forEach((n: any) => validateNodeData(n));
+}
+
+export function safeJsonParse(json?: string) {
+  let parsed;
+  try {
+    parsed = json ? JSON.parse(json) : undefined;
+  }
+  catch (e) {
+    // swallow errors
+  }
+  return parsed;
+}

--- a/src/serialization/serialization.ts
+++ b/src/serialization/serialization.ts
@@ -147,6 +147,11 @@ export function deserializeElement(node: SlateElement, objTypes: ObjectTypeMap):
   const object = (objTypes[type] || "block") as any;
   const nodes = deserializeChildren(children, objTypes);
   const data = size(others) ? { data: others } : {};
+  // "className" should be converted to "class" on import but it wasn't always so
+  if ("className" in others) {
+    others.className && (others.class = others.className);
+    delete others.className;
+  }
   return { object, type, ...keyProp(key), nodes, ...data };
 }
 


### PR DESCRIPTION
The symptom was a console error from React about an invalid `classNamename` property. I suspect the problem began with an import of invalid hand-coded HTML which looked something like `<ul><li className="foo">bar</li></ul>` which then introduced the `className` property into the system after which it was copied around to several other places. The fix here is to strip it out or convert it to `class` on import/export depending on circumstances.

Also adds some additional unit tests.