### PR TITLE
Release 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 0.7.2 - February 26, 2021
+
+- Convert/strip `className` property on import/export
+- Update dependencies
+
 ## Version 0.7.1 - February 11, 2021
 
 - Support legacy `line` block type (synonym for `paragraph`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/slate-editor",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/slate-editor",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Slate-based rich text editor component for use in CC projects",
   "main": "build/index.js",
   "module": "build/index.esm.js",


### PR DESCRIPTION
## Version 0.7.2 - February 26, 2021

- Convert/strip `className` property on import/export
- Update dependencies
