### PR TITLE
Refactored `variable` plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,7 +38,8 @@ module.exports = {
       "eslint-comments/no-unused-disable": "warn",
       "no-debugger": "off",
       "no-shadow": ["error", { "builtinGlobals": false, "hoist": "all", "allow": [] }],
-      "no-unused-vars": "off",  // superceded by @typescript-eslint/no-unused-vars
+      "no-unused-vars": "off",  // superseded by @typescript-eslint/no-unused-vars
+      "prefer-const": ["error", { destructuring: "all" }],
       "react/prop-types": "off",
       semi: ["error", "always"]
     }

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 .DS_Store
 build
 coverage
+dist
 node_modules
+stats.html
 storybook-static
+.yalc
+yalc.lock

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,7 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "cSpell.words": [
+    "ccrte",
+    "inlines"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
-    "unlink:react": "npm unlink -g react"
+    "unlink:react": "npm unlink -g react",
+    "yalc:publish": "npx yalc publish --push",
+    "yalc:unpublish": "npx yalc installations clean @concord-consortium/slate-editor"
   },
   "author": "Concord Consortium",
   "license": "MIT",

--- a/src/common/slate-types.ts
+++ b/src/common/slate-types.ts
@@ -57,23 +57,41 @@ export type EditorValue = Value;
 export type EditorContent = Document;
 export const EditorRange = Range;
 
-export function isMarkFormat(format: EFormat) {
-  return [
-    EFormat.bold, EFormat.italic, EFormat.underlined, EFormat.inserted, EFormat.deleted,
-    EFormat.code, EFormat.marked, EFormat.superscript, EFormat.subscript, EFormat.color
-  ].includes(format);
+const markFormats: Array<EFormat | string> = [
+  EFormat.bold, EFormat.italic, EFormat.underlined, EFormat.inserted, EFormat.deleted,
+  EFormat.code, EFormat.marked, EFormat.superscript, EFormat.subscript, EFormat.color
+];
+
+export function registerMarkFormat(format: string) {
+  markFormats.push(format);
+}
+
+export function isMarkFormat(format: EFormat | string) {
+  return markFormats.includes(format);
+}
+
+const blockFormats: Array<EFormat | string> = [
+  EFormat.paragraph, EFormat.block, EFormat.blockQuote, EFormat.heading1, EFormat.heading2,
+  EFormat.heading3, EFormat.heading4, EFormat.heading5, EFormat.heading6, EFormat.horizontalRule,
+  EFormat.preformatted, EFormat.listItem, EFormat.numberedList, EFormat.bulletedList, EFormat.lineDEPRECATED
+];
+
+export function registerBlockFormat(format: string) {
+  blockFormats.push(format);
 }
 
 export function isBlockFormat(format: EFormat) {
-  return [
-    EFormat.paragraph, EFormat.block, EFormat.blockQuote, EFormat.heading1, EFormat.heading2,
-    EFormat.heading3, EFormat.heading4, EFormat.heading5, EFormat.heading6, EFormat.horizontalRule,
-    EFormat.preformatted, EFormat.listItem, EFormat.numberedList, EFormat.bulletedList, EFormat.lineDEPRECATED
-  ].includes(format);
+  return blockFormats.includes(format);
+}
+
+const inlineFormats: Array<EFormat | string> = [EFormat.inline, EFormat.image, EFormat.link];
+
+export function registerInlineFormat(format: string) {
+  inlineFormats.push(format);
 }
 
 export function isInlineFormat(format: EFormat) {
-  return [EFormat.inline, EFormat.image, EFormat.link].includes(format);
+  return inlineFormats.includes(format);
 }
 
 export function textToSlate(text: string): EditorValue {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,7 +12,7 @@ export {
 export { SlateContainer } from "./slate-container/slate-container";
 export { SlateEditor } from "./slate-editor/slate-editor";
 export { getContentHeight, handleToggleSuperSubscript } from "./slate-editor/slate-utils";
-export { DisplayDialogSettings, IToolOrder, OrderEntry, SlateToolbar } from "./slate-toolbar/slate-toolbar";
+export { DisplayDialogSettings, SlateToolbar, ToolbarTransform } from "./slate-toolbar/slate-toolbar";
 export { EditorToolbar, IButtonSpec, IToolbarColors, getPlatformTooltip } from "./editor-toolbar/editor-toolbar";
 export {
   OnChangeColorFn, OnChangeFn, OnClickFn, OnDidInvokeToolFn, OnMouseFn, ToolbarButton

--- a/src/plugin-examples/icon-variable.tsx
+++ b/src/plugin-examples/icon-variable.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { IconProps } from "../assets/icon-props";
+
+export default function IconVariable(props: IconProps) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" {...props}>
+        <text textAnchor="middle" x="50%" y="12">v=</text>
+    </svg>
+  );
+}

--- a/src/plugin-examples/plugin-examples.stories.tsx
+++ b/src/plugin-examples/plugin-examples.stories.tsx
@@ -1,0 +1,67 @@
+import React, { useCallback, useRef, useState } from "react";
+import { Value } from "slate";
+import IconVariable from "./icon-variable";
+import { textToSlate } from "../common/slate-types";
+import { VariablesPlugin } from "./variable-plugin";
+import { IProps as ISlateToolbarProps, SlateToolbar, ToolbarTransform } from "../slate-toolbar/slate-toolbar";
+import { getPlatformTooltip, IButtonSpec } from "../editor-toolbar/editor-toolbar";
+import { IProps as ISlateEditorProps, SlateEditor } from "../slate-editor/slate-editor";
+import { Editor } from "slate-react";
+
+export default {
+  title: "Plugin Examples"
+};
+
+const variablesText = "This example demonstrates a customized toolbar/editor with embedded variables in text.";
+
+const VariablesToolbar = (props: ISlateToolbarProps) => {
+  const transform = useCallback<ToolbarTransform>((buttons, editor, dialogController) => {
+    return [
+      ...["bold", "italic"]
+            .map(format => buttons.find(b => b.format === format))
+            .filter(b => !!b),
+      {
+        format: "variable",
+        SvgIcon: IconVariable,
+        tooltip: getPlatformTooltip("variable"),
+        isActive: !!editor && editor.query("isVariableActive"),
+        isEnabled: !!editor && editor.query("isVariableEnabled"),
+        onClick: () => {
+          editor?.command("configureVariable", dialogController);
+        }
+      }
+     ] as IButtonSpec[];
+  }, []);
+  return (
+    <SlateToolbar transform={transform} {...props} />
+  );
+};
+
+interface IVariablesProps extends Omit<ISlateEditorProps, "value" | "onValueChange"> {}
+export const Variables = (props: IVariablesProps) => {
+  const [value, setValue] = useState(textToSlate(variablesText));
+  const [changeCount, setChangeCount] = useState(0);
+  const editorRef = useRef<Editor>();
+  const handleEditorRef = useCallback((editor?: Editor) => {
+    editorRef.current = editor;
+    setChangeCount(count => ++count);
+  }, []);
+  const variablesPlugin = VariablesPlugin({ a: 1, b: 2, c: 3 });
+  const plugins = [variablesPlugin];
+  return (
+    <div className={`variables-example`}>
+      <VariablesToolbar editor={editorRef.current} changeCount={changeCount} />
+      <SlateEditor
+        plugins={plugins}
+        onEditorRef={handleEditorRef}
+        value={value}
+        onValueChange={(_value: Value) => {
+          setValue(_value);
+          // trigger toolbar rerender on selection change as well
+          setChangeCount(count => ++count);
+        }}
+        {...props}
+      />
+    </div>
+  );
+};

--- a/src/plugin-examples/plugin-examples.stories.tsx
+++ b/src/plugin-examples/plugin-examples.stories.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useRef, useState } from "react";
 import { Value } from "slate";
 import IconVariable from "./icon-variable";
 import { textToSlate } from "../common/slate-types";
-import { VariablesPlugin } from "./variable-plugin";
+import { kVariableFormatCode, VariablesPlugin } from "./variable-plugin";
 import { IProps as ISlateToolbarProps, SlateToolbar, ToolbarTransform } from "../slate-toolbar/slate-toolbar";
 import { getPlatformTooltip, IButtonSpec } from "../editor-toolbar/editor-toolbar";
 import { IProps as ISlateEditorProps, SlateEditor } from "../slate-editor/slate-editor";
@@ -12,16 +12,23 @@ export default {
   title: "Plugin Examples"
 };
 
+/*
+ * Variables
+ *
+ * Supports creation/editing of variable "chips" with optional values embedded in text.
+ */
 const variablesText = "This example demonstrates a customized toolbar/editor with embedded variables in text.";
 
 const VariablesToolbar = (props: ISlateToolbarProps) => {
   const transform = useCallback<ToolbarTransform>((buttons, editor, dialogController) => {
     return [
+      // add the default buttons we care about to the toolbar
       ...["bold", "italic"]
             .map(format => buttons.find(b => b.format === format))
             .filter(b => !!b),
+      // add a new button for inserting/editing variable chips
       {
-        format: "variable",
+        format: kVariableFormatCode,
         SvgIcon: IconVariable,
         tooltip: getPlatformTooltip("variable"),
         isActive: !!editor && editor.query("isVariableActive"),

--- a/src/plugin-examples/variable-plugin.scss
+++ b/src/plugin-examples/variable-plugin.scss
@@ -1,0 +1,15 @@
+.ccrte-variable {
+  border: 1px solid black;
+  border-radius: 5px;
+  padding: 1px 3px;
+  margin: 0 1px;
+  user-select: none;
+
+  .ccrte-equals {
+    padding: 0 3px;
+  }
+}
+
+.ccrte-variable-highlight {
+  box-shadow: 0 0 0 2px lightskyblue;
+}

--- a/src/plugin-examples/variable-plugin.tsx
+++ b/src/plugin-examples/variable-plugin.tsx
@@ -1,0 +1,195 @@
+import React, { ReactNode } from "react";
+import classNames from "classnames/dedupe";
+import clone from "lodash/clone";
+import { Inline } from "slate";
+import { Editor, RenderAttributes, RenderInlineProps } from "slate-react";
+import { kSlateVoidClass, registerInlineFormat } from "../common/slate-types";
+import { hasActiveInline } from "../slate-editor/slate-utils";
+import { IFieldValues } from "../slate-toolbar/modal-dialog";
+import { IDialogController } from "../slate-toolbar/slate-toolbar";
+import { getDataFromElement, getRenderAttributesFromNode, classArray } from "../serialization/html-utils";
+import { HtmlSerializablePlugin } from "../plugins/html-serializable-plugin";
+import "./variable-plugin.scss";
+
+export const kVariableFormatCode = "variable";
+registerInlineFormat(kVariableFormatCode);
+
+function isEmptyValue(value?: number | string) {
+  return (value == null) || (value === "");
+}
+
+function parseVariableValue(value?: string) {
+  return value ? parseFloat(value) : undefined;
+}
+
+function formatVariableValue(value?: number) {
+  return value != null ? (Math.round(100 * value) / 100).toString() : "";
+}
+
+const kVariableClass = "ccrte-variable";
+const kVariableHighlightClass = "ccrte-variable-highlight";
+
+interface IRenderOptions {
+  isSerializing?: boolean;
+  isHighlighted?: boolean;
+  onClick?: () => void;
+  onDoubleClick?: () => void;
+}
+function renderVariable(node: Inline, attributes: RenderAttributes, children: ReactNode, options?: IRenderOptions) {
+  const { data } = node;
+  const { className, ...otherAttributes } = attributes;
+  const { isHighlighted, isSerializing, onClick: _onClick, onDoubleClick: _onDoubleClick } = options || {};
+  const highlightClass = isHighlighted && !isSerializing ? kVariableHighlightClass : undefined;
+  const name: string = data.get("name");
+  const value: string = data.get("value");
+  const hasValue = !isEmptyValue(value);
+  const classes = classNames(classArray(className), kSlateVoidClass, kVariableClass, highlightClass) || undefined;
+  const onClick = isSerializing ? undefined : _onClick;
+  const onDoubleClick = isSerializing ? undefined : _onDoubleClick;
+  return (
+    <span className={classes} onClick={onClick} onDoubleClick={onDoubleClick} {...otherAttributes}>
+      <span className="ccrte-name">{name}</span>
+      {hasValue && <span className="ccrte-equals">=</span>}
+      {hasValue && <span className="ccrte-value">{value}</span>}
+    </span>
+  );
+}
+
+function getDataFromVariableElement(el: Element) {
+  const { data } = getDataFromElement(el);
+  const _data: Record<string, string | number | boolean | undefined> = clone(data) || {};
+  if (data?.name) {
+    _data.name = data.name;
+  }
+  _data.value = parseVariableValue(data?.value);
+  return { data: _data };
+}
+
+function getDialogValuesFromNode(editor: Editor, node?: Inline) {
+  const values: Record<string, string> = {};
+  const { data } = node || {};
+  const highlightedText = editor.value.fragment.text;
+  let name, value;
+  if (highlightedText) {
+    values.name = highlightedText;
+  }
+  else if ((name = data?.get("name"))) {
+    values.name = name;
+  }
+  if ((value = data?.get("value"))) {
+    values.value = value;
+  }
+  return values;
+}
+
+const kSpanTag = "span";
+
+export function VariablesPlugin(variables: Record<string, number>): HtmlSerializablePlugin {
+  return {
+    deserialize: function(el, next) {
+      if ((el.tagName.toLowerCase() === kSpanTag) && el.classList.contains(kVariableClass)) {
+        const data = getDataFromVariableElement(el);
+        return {
+          object: "inline",
+          type: kVariableFormatCode,
+          ...data,
+          nodes: next(el.childNodes),
+        };
+      }
+    },
+    serialize: function(obj, children) {
+      const { object, type } = obj;
+      if ((object === "inline") && (type === kVariableFormatCode)) {
+        const variable: Inline = obj;
+        const omits = ["name", "value"];
+        return renderVariable(variable, getRenderAttributesFromNode(variable, omits),
+                              children, { isSerializing: true });
+      }
+    },
+
+    queries: {
+      isVariableActive: function(editor: Editor) {
+        return hasActiveInline(editor.value, kVariableFormatCode);
+      },
+      isVariableEnabled: function(editor: Editor) {
+        return (editor.value.blocks.size <= 1) && (editor.value.inlines.size === 0);
+      }
+    },
+    commands: {
+      configureVariable: function (editor: Editor, dialogController: IDialogController, node?: Inline) {
+        dialogController.display({
+          title: "Insert Variable",
+          rows: [
+            {
+              name: "reference", type: "select", label: "Reference existing variable:",
+              options: Object.keys(variables).map(v => ({ value: v, label: v }))
+            },
+            { name: "or", type: "label", label: "or" },
+            { name: "create", type: "label", label: "Create new variable:" },
+            [
+              { name: "name", type: "input", label: "Name:" },
+              { name: "value", type: "input", label: "Value:" }
+            ]
+          ],
+          values: getDialogValuesFromNode(editor, node),
+          onChange: (_editor, name, value, values) => {
+            if (name === "name") {
+              dialogController.update({ name: value });
+            }
+            else if (name === "value") {
+              if (parseFloat(value) == null) return false;
+              dialogController.update({ value });
+            }
+          },
+          onValidate: (values) => {
+            return values.reference || values.name ? values : "Error: invalid name";
+          },
+          onAccept: (_editor, values) => {
+            // ... make any necessary changes to the shared model
+            return _editor.command("addVariable", values, node);
+          }
+        });
+        return editor;
+      },
+      addVariable: function (editor: Editor, values: IFieldValues, node?: Inline) {
+        let { reference, name, value } = values;
+        if (!editor || (!reference && !name && !value)) return editor;
+        if (node) {
+          editor.moveToStartOfNode(node)
+                .deleteForward();
+        }
+        if (reference) {
+          name = reference;
+          value = formatVariableValue(variables[name]);
+        }
+        editor.insertInline({
+          type: kVariableFormatCode,
+          data: { name, value }
+        });
+        return editor;
+      },
+    },
+    schema: {
+      inlines: {
+        [kVariableFormatCode]: {
+          isVoid: true
+        }
+      }
+    },
+
+    renderInline: (props: RenderInlineProps, editor: Editor, next: () => any) => {
+      const { attributes, node, children } = props;
+      if (node.type !== kVariableFormatCode) return next();
+      const omits = ["name", "value"];
+      const dataAttrs = getRenderAttributesFromNode(node, omits);
+
+      const options: IRenderOptions = {
+        isSerializing: false,
+        isHighlighted: props.isSelected || props.isFocused,
+        onClick: () => editor.moveFocusToStartOfNode(node),
+        onDoubleClick: () => editor.command("emit", "toolbarDialog", "configureVariable", node)
+      };
+      return renderVariable(node, { ...dataAttrs, ...attributes }, children, options);
+    }
+  };
+}

--- a/src/slate-container/slate-container.stories.tsx
+++ b/src/slate-container/slate-container.stories.tsx
@@ -75,7 +75,7 @@ const portalText = "This example demonstrates rendering the toolbar in a React p
                   " hierarchy) as well as hiding/showing the toolbar on blur/focus.";
 export const Portal = () => {
   const editorRef = useRef<Editor>();
-  const blurTimer = useRef<NodeJS.Timeout>();
+  const blurTimer = useRef<number>();
   const [isFocused, setIsFocused] = useState(false);
   const [value, setValue] = useState(textToSlate(portalText));
   const [portalRoot, setPortalRoot] = useState<HTMLDivElement>();

--- a/src/slate-editor/slate-editor.test.tsx
+++ b/src/slate-editor/slate-editor.test.tsx
@@ -1,5 +1,7 @@
 import EventEmitter from "eventemitter3";
 import React from "react";
+// not being picked up from `jest.setup.ts` for some reason
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import { Editor } from "slate-react";
 import { slateToText, textToSlate } from "../common/slate-types";

--- a/src/slate-editor/slate-utils.ts
+++ b/src/slate-editor/slate-utils.ts
@@ -63,7 +63,7 @@ export function selectionContainsBlock(value: Value, format: EFormat) {
   return nodes.some(node => !Text.isText(node) && (node?.type === format));
 }
 
-export function hasActiveInline(value: Value, format: EFormat) {
+export function hasActiveInline(value: Value, format: EFormat | string) {
   return value.inlines.some(inline => inline?.type === format);
 }
 

--- a/src/slate-toolbar/slate-toolbar.stories.tsx
+++ b/src/slate-toolbar/slate-toolbar.stories.tsx
@@ -1,5 +1,6 @@
-import React from "react";
-import { SlateToolbar } from "./slate-toolbar";
+import React, { useCallback } from "react";
+import { IButtonSpec } from "../editor-toolbar/editor-toolbar";
+import { SlateToolbar, ToolbarTransform } from "./slate-toolbar";
 
 export default {
   title: "SlateToolbar"
@@ -41,26 +42,42 @@ const order = [
         "fontIncrease", "heading1", "heading2", "heading3", "block-quote", "bulleted-list", "ordered-list", "image", "link"
       ];
 
-export const Ordered = () => (
-  <SlateToolbar changeCount={0}
-    orientation="vertical"
-    colors={{ buttonColors: { background: "#177991", fill: "#ffffff" } }}
-    buttonsPerRow={9}
-    order={order}
-    />
-);
+export const Ordered = () => {
+  const transform = useCallback<ToolbarTransform>(buttons => {
+    return order
+            .map(format => buttons.find(b => b.format === format))
+            .filter(b => !!b) as IButtonSpec[];
+  }, []);
+  return (
+    <SlateToolbar changeCount={0}
+      orientation="vertical"
+      colors={{ buttonColors: { background: "#177991", fill: "#ffffff" } }}
+      buttonsPerRow={9}
+      transform={transform}
+      />
+  );
+};
 
-const hintedOrder = order
-                      // show subset of tools
-                      .filter((f, i) => (i + 1) % 4 !== 0)
-                      .reverse()
-                      // override tooltips
-                      .map(f => ({ format: f, tooltip: `hint: ${f}`}) );
-export const OrderedHinted = () => (
-  <SlateToolbar changeCount={0}
-    orientation="vertical"
-    colors={{ buttonColors: { background: "#177991", fill: "#ffffff" } }}
-    buttonsPerRow={7}
-    order={hintedOrder}
-    />
-);
+export const OrderedHinted = () => {
+  const transform = useCallback<ToolbarTransform>(buttons => {
+    return order
+            // show subset of tools
+            .filter((f, i) => (i + 1) % 4 !== 0)
+            .reverse()
+            .map(format => buttons.find(b => b.format === format))
+            // override tooltips
+            .map(b => {
+              const { tooltip, ...others } = b || {};
+              return { ...others, tooltip: tooltip ? `hint: ${tooltip}` : tooltip };
+            })
+            .filter(b => !!b) as IButtonSpec[];
+  }, []);
+  return (
+    <SlateToolbar changeCount={0}
+      orientation="vertical"
+      colors={{ buttonColors: { background: "#177991", fill: "#ffffff" } }}
+      buttonsPerRow={7}
+      transform={transform}
+      />
+  );
+};


### PR DESCRIPTION
This is an updated implementation of the `variable` plugin that no longer requires intrusive changes into the core components and therefore is mergeable as an example of a non-trivial plugin that can be built entirely in userland. A few changes were made to the core `slate-editor` code to support such plugins:
1. Client code can extend the `EFormat` codes by adding their own strings.
2. The `SlateToolbar` component now accepts a `transform` function which can modify the set of default buttons. Previously, there was a mechanism for ordering and filtering the set of default buttons but there was no way to add new buttons and only limited facility for changing the existing buttons. All of this can now be accomplished with the `transform` function. Previous examples which demonstrated the ordering/filtering have been rewritten to use this new capability.

Note that since this could potentially impact existing clients of the previous ordering/filtering capability, it should be deployed with a version bump as well, i.e. `0.8.0` rather than `0.7.4`.

A note on naming: I started out thinking of this as the `variable` plugin. At some point I talked myself into it being the `variables` plugin instead, because it has knowledge of a set of variables. But we don't name any of our other plugins that way (e.g. the `image` and `link` plugins), so I've gone back to naming it the `variable` plugin.

~~This will probably never be merged as the functionality properly belongs in the client application (e.g. CLUE), but for development and demo purposes it's convenient to be able to work on it here in the `slate-editor` repo where one can focus on the text-editing pieces of the problem without having to worry about publishing here and subscribing elsewhere.~~

Things that could potentially be worked on here without involving CLUE:
1. ~~If text is selected when the toolbar button is pressed, prepopulate the name field with the selected text.~~ ✅ 
4. After inserting a chip (or image for that matter), the caret should be immediately after the chip/image so that the user can continue typing.
5. ~~Enable cut/copy/paste of solo chips (already works for chips within embedded text).~~ ✅ 
6. Enable dragging of chips (already works for simple text).
7. Enable formatting of chip contents (e.g. bold/italic/etc.).
8. ~~Add dialog controls for enabling/disabling rounding and specify # digits to which to round.~~ ❌  (client responsibility)