### PR TITLE
Support clipboard operations on image-only selections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.7.3",
       "license": "MIT",
       "dependencies": {
-        "@concord-consortium/slate-react": "^0.22.10-cc.3",
+        "@concord-consortium/slate-react": "^0.22.10-cc.4",
         "classnames": "^2.3.1",
         "eventemitter3": "^4.0.7",
         "immutable": "^3.8.2",
@@ -2933,9 +2933,9 @@
       "dev": true
     },
     "node_modules/@concord-consortium/slate-react": {
-      "version": "0.22.10-cc.3",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-react/-/slate-react-0.22.10-cc.3.tgz",
-      "integrity": "sha512-wYGAHZf62ygpPlgHXvXWCg/waf59ZHoFoeAvC/7A9v5qJcMPaL1QkCIsdGJXTKqSK+GMdwttNAix0A2ECDe0xg==",
+      "version": "0.22.10-cc.4",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-react/-/slate-react-0.22.10-cc.4.tgz",
+      "integrity": "sha512-DYRqGERnJFfRfIWyt0kbkLUHnMGGybpvG3pUq4Brgw/HEK7W66DUmnDIYwJcFJs2CsXBRwcyVonLqZf9WuqXRA==",
       "dependencies": {
         "debug": "^3.1.0",
         "get-window": "^1.1.1",
@@ -28428,9 +28428,9 @@
       "dev": true
     },
     "@concord-consortium/slate-react": {
-      "version": "0.22.10-cc.3",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-react/-/slate-react-0.22.10-cc.3.tgz",
-      "integrity": "sha512-wYGAHZf62ygpPlgHXvXWCg/waf59ZHoFoeAvC/7A9v5qJcMPaL1QkCIsdGJXTKqSK+GMdwttNAix0A2ECDe0xg==",
+      "version": "0.22.10-cc.4",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-react/-/slate-react-0.22.10-cc.4.tgz",
+      "integrity": "sha512-DYRqGERnJFfRfIWyt0kbkLUHnMGGybpvG3pUq4Brgw/HEK7W66DUmnDIYwJcFJs2CsXBRwcyVonLqZf9WuqXRA==",
       "requires": {
         "debug": "^3.1.0",
         "get-window": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@concord-consortium/slate-react": "^0.22.10-cc.3",
+    "@concord-consortium/slate-react": "^0.22.10-cc.4",
     "classnames": "^2.3.1",
     "eventemitter3": "^4.0.7",
     "immutable": "^3.8.2",

--- a/src/common/slate-types.ts
+++ b/src/common/slate-types.ts
@@ -43,6 +43,8 @@ export enum EFormat {
   link = "link" // <a>
 }
 
+export const kSlateVoidClass = "cc-slate-void";
+
 // eslint-disable-next-line no-shadow
 export enum EMetaFormat {
   fontIncrease = "fontIncrease",

--- a/src/plugins/image-plugin.tsx
+++ b/src/plugins/image-plugin.tsx
@@ -4,7 +4,7 @@ import clone from "lodash/clone";
 import { isWebUri } from "valid-url";
 import { Inline } from "slate";
 import { Editor, RenderAttributes, RenderInlineProps } from "slate-react";
-import { EFormat } from "../common/slate-types";
+import { EFormat, kSlateVoidClass } from "../common/slate-types";
 import { hasActiveInline } from "../slate-editor/slate-utils";
 import { IFieldValues } from "../slate-toolbar/modal-dialog";
 import { IDialogController } from "../slate-toolbar/slate-toolbar";
@@ -46,7 +46,8 @@ function renderImage(node: Inline, attributes: RenderAttributes, children: React
   const constrain: boolean = data.get("constrain") !== false;
   const constrainClass = constrain ? undefined : "ccrte-no-constrain";
   const floatClasses = getClassesForFloatValue(data.get("float"));
-  const classes = classNames(classArray(className), highlightClass, constrainClass, floatClasses) || undefined;
+  const classes = classNames(classArray(className), highlightClass,
+                              kSlateVoidClass, constrainClass, floatClasses) || undefined;
   const onLoad = options?.isSerializing ? undefined : options?.onLoad;
   const onClick = options?.isSerializing ? undefined : options?.onClick;
   const onDoubleClick = options?.isSerializing ? undefined : options?.onDoubleClick;

--- a/src/serialization/html-serializer.test.tsx
+++ b/src/serialization/html-serializer.test.tsx
@@ -144,8 +144,8 @@ describe("htmlToSlate(), slateToHtml()", () => {
 
   it("can [de]serialize images", () => {
     [
-      `<p><img src="https://concord.org/wp-content/themes/concord2017/images/concord-logo.svg"/></p>`,
-      `<p><img class="my-image-class" src="https://concord.org/wp-content/themes/concord2017/images/concord-logo.svg"/></p>`
+      `<p><img class="cc-slate-void" src="https://concord.org/wp-content/themes/concord2017/images/concord-logo.svg"/></p>`,
+      `<p><img class="my-image-class cc-slate-void" src="https://concord.org/wp-content/themes/concord2017/images/concord-logo.svg"/></p>`
     ].forEach(html => expect(slateToHtml(htmlToSlate(html))).toBe(html));
   });
 


### PR DESCRIPTION
Makes use of [@concord-consortium/slate #5](https://github.com/concord-consortium/slate/pull/5) to enable cut/copy/paste of image-only selections.