### PR TITLE
export more stuff to support external plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@concord-consortium/slate-editor",
-  "version": "0.7.4",
+  "version": "0.8.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@concord-consortium/slate-editor",
-      "version": "0.7.4",
+      "version": "0.8.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@concord-consortium/slate-react": "^0.22.10-cc.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/slate-editor",
-  "version": "0.7.4",
+  "version": "0.8.0-beta.2",
   "description": "Slate-based rich text editor component for use in CC projects",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 export { DocumentJSON } from "slate";
-export { Editor } from "slate-react";
+export { Editor, RenderAttributes, RenderInlineProps } from "slate-react";
 export { EditorContent, EditorRange, EditorValue, EFormat, slateToText, textToSlate } from "./common/slate-types";
 export { DialogContent } from "./modal-dialog/dialog-content";
 export { DialogFooter } from "./modal-dialog/dialog-footer";
@@ -8,9 +8,10 @@ export {
   DisplayDialogSettings, FieldType, IDialogController, IField, IFieldValues, IRow, SelectOptions, SelectValue
 } from "./modal-dialog/dialog-types";
 export { ModalCover } from "./modal-dialog/modal-cover";
-export { ModalDialog } from "./modal-dialog/modal-dialog";
+export { ModalDialog, IProps as IModalDialogProps } from "./modal-dialog/modal-dialog";
 export { HtmlSerializablePlugin } from "./plugins/html-serializable-plugin";
 export { htmlToSlate, slateToHtml } from "./serialization/html-serializer";
+export { getDataFromElement, getRenderAttributesFromNode, classArray } from "./serialization/html-utils";
 export {
   deserializeValueFromLegacy, serializeValueToLegacy, validateNodeData
 } from "./serialization/legacy-serialization";
@@ -19,7 +20,7 @@ export {
 } from "./serialization/serialization";
 export { SlateContainer } from "./slate-container/slate-container";
 export { SlateEditor } from "./slate-editor/slate-editor";
-export { getContentHeight, handleToggleSuperSubscript } from "./slate-editor/slate-utils";
+export { getContentHeight, handleToggleSuperSubscript, hasActiveInline } from "./slate-editor/slate-utils";
 export { SlateToolbar, ToolbarTransform } from "./slate-toolbar/slate-toolbar";
 export { EditorToolbar, IButtonSpec, IToolbarColors, getPlatformTooltip } from "./editor-toolbar/editor-toolbar";
 export {


### PR DESCRIPTION
this also sets the version 0.8.0-beta.2

The changes here are used by this CLUE PR: https://github.com/concord-consortium/collaborative-learning/pull/1257