### PR TITLE
Wrap free text nodes when importing HTML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@concord-consortium/slate-editor",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@concord-consortium/slate-editor",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@emotion/css": "^11.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/slate-editor",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Slate-based rich text editor component for use in CC projects",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/common/slate-types.ts
+++ b/src/common/slate-types.ts
@@ -54,9 +54,16 @@ export type EditorValue = Descendant[];
 
 export type HotkeyMap = Record<string, (editor: Editor) => void>;
 
+export function wrapInParagraph(_children: Descendant | Descendant[]) {
+  const children = Array.isArray(_children)
+    ? _children
+    : [_children];
+  return {type: "paragraph", children };
+}
+
 export function textToSlate(text: string): EditorValue {
   const lines = text.split(/\r|\r?\n/);
-  return lines.map(line => ({ type: "paragraph", children: [{ text: line }] }));
+  return lines.map(line => (wrapInParagraph([{ text: line }])));
 }
 
 export function slateToText(value: EditorValue = []) {

--- a/src/serialization/html-serializer.test.tsx
+++ b/src/serialization/html-serializer.test.tsx
@@ -160,6 +160,17 @@ describe("htmlToSlate(), slateToHtml()", () => {
     ].forEach(html => expect(slateToHtml(htmlToSlate(html))).toBe(html));
   });
 
+  it("adds paragraphs around floating text", () => {
+    const html = "Free text";
+    expect(slateToHtml(htmlToSlate(html))).toBe(`<p>${html}</p>`);
+    const boldHtml = "<strong>Bold text</strong>";
+    expect(slateToHtml(htmlToSlate(boldHtml))).toBe(`<p>${boldHtml}</p>`);
+    // Currently each node gets wrapped in its own <p> tag, which might not be the desired behavior.
+    expect(slateToHtml(htmlToSlate(`${html}${boldHtml}`))).toBe(`<p>${html}</p><p>${boldHtml}</p>`);
+    const pHtml = "<p>Paragraph</p>";
+    expect(slateToHtml(htmlToSlate(`${html}${pHtml}${boldHtml}`))).toBe(`<p>${html}</p>${pHtml}<p>${boldHtml}</p>`);
+  });
+
   it("can [de]serialize images", () => {
     [
       `<p><img class="cc-slate-void" src="https://concord.org/wp-content/themes/concord2017/images/concord-logo.svg"/></p>`,

--- a/src/serialization/html-serializer.tsx
+++ b/src/serialization/html-serializer.tsx
@@ -4,6 +4,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { Descendant } from "slate";
 import { jsx } from "slate-hyperscript";
 import { CustomMarks, isLeafTextNode } from "../common/custom-types";
+import { wrapInParagraph } from "../common/slate-types";
 import { SerializingContext } from "../hooks/use-serializing";
 import { Element } from "../slate-editor/element";
 import { Leaf } from "../slate-editor/leaf";
@@ -57,10 +58,7 @@ export function htmlToSlate(html: string) {
         // If they're empty (like a `\n` for a multiline html), skip them.
         // If they have content, wrap them in a paragraph node.
         if (/\S/.test(node.text)) {
-          processed.push({
-            type: "paragraph",
-            children: [node]
-          });
+          processed.push(wrapInParagraph(node));
         }
       } else {
         processed.push(node);

--- a/src/serialization/serialization.stories.tsx
+++ b/src/serialization/serialization.stories.tsx
@@ -135,7 +135,7 @@ export const ClueSerialization = () => (
   />
 );
 
-const importedHtmlText = "<h1>A header paragraph</h1><p>A simple paragraph.</p><blockquote>A quoted paragraph.</blockquote>";
+const importedHtmlText = "Text outside of a paragraph tag should be wrapped when imported.<b>So should bold text</b><h1>A header paragraph</h1><p>A simple paragraph.</p><blockquote>A quoted paragraph.</blockquote>";
 
 export const ImportedHTML = () => (
   <SerializationStory


### PR DESCRIPTION
Some CLUE curriculum files include improperly formatted HTML, in that some text is not wrapped in `<p>` or other block tags. These were being imported into slate as top level text nodes, which are not allowed and caused errors. This fix checks all top level text nodes when importing HTML, removes those with just whitespace, and wraps those with actual content in paragraph nodes.