### PR TITLE
chore: release 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
 # Changelog
 
+## Version 0.10.1 - July 24, 2024
+
+### Features/Improvements
+- Export `isCustomElement()` function
+
+### Bugs Fixed
+- Fix bug in `ReactEditor.focus()` by downgrading to `slate-react` 0.98.4
+
 ## Version 0.10.0 - July 24, 2024
 
 ### Features/Improvements
-- Update `slate` to 0.103.0, `slate-react` to 0.99.0, `storybook` to 8.2.5 among other dependencies.
+- Update `slate` to 0.103.0, `slate-react` to 0.99.0, `storybook` to 8.2.5 among other dependencies
 
 ### Bugs Fixed
 - Reduce bundle size (eliminate redundant lodash import)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@concord-consortium/slate-editor",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@concord-consortium/slate-editor",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "MIT",
       "dependencies": {
         "@emotion/css": "^11.13.0",
@@ -20,7 +20,7 @@
         "slate": "^0.103.0",
         "slate-history": "^0.100.0",
         "slate-hyperscript": "^0.100.0",
-        "slate-react": "~0.99.0",
+        "slate-react": "~0.98.4",
         "style-to-object": "^1.0.6",
         "tslib": "^2.6.3",
         "valid-url": "^1.0.9"
@@ -17636,9 +17636,9 @@
       }
     },
     "node_modules/slate-react": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.99.0.tgz",
-      "integrity": "sha512-E+mU87L5epS/Cj9Z35aRkTEMrBXdX8URbFh8B2zTq2DDQKn+MT6/ag41g1InMdRoQ/kipGsbtcrM8dEicY8o/Q==",
+      "version": "0.98.4",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.98.4.tgz",
+      "integrity": "sha512-8Of3v9hFuX8rIRc86LuuBhU9t8ps+9ARKL4yyhCrKQYZ93Ep/LFA3GvPGvtf3zYuVadZ8tkhRH8tbHOGNAndLw==",
       "dependencies": {
         "@juggle/resize-observer": "^3.4.0",
         "@types/is-hotkey": "^0.1.1",
@@ -32593,9 +32593,9 @@
       }
     },
     "slate-react": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.99.0.tgz",
-      "integrity": "sha512-E+mU87L5epS/Cj9Z35aRkTEMrBXdX8URbFh8B2zTq2DDQKn+MT6/ag41g1InMdRoQ/kipGsbtcrM8dEicY8o/Q==",
+      "version": "0.98.4",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.98.4.tgz",
+      "integrity": "sha512-8Of3v9hFuX8rIRc86LuuBhU9t8ps+9ARKL4yyhCrKQYZ93Ep/LFA3GvPGvtf3zYuVadZ8tkhRH8tbHOGNAndLw==",
       "requires": {
         "@juggle/resize-observer": "^3.4.0",
         "@types/is-hotkey": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/slate-editor",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Slate-based rich text editor component for use in CC projects",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
@@ -105,7 +105,7 @@
     "slate": "^0.103.0",
     "slate-history": "^0.100.0",
     "slate-hyperscript": "^0.100.0",
-    "slate-react": "~0.99.0",
+    "slate-react": "~0.98.4",
     "style-to-object": "^1.0.6",
     "tslib": "^2.6.3",
     "valid-url": "^1.0.9"

--- a/src/common/custom-types.ts
+++ b/src/common/custom-types.ts
@@ -1,4 +1,4 @@
-import { Descendant, BaseEditor, BaseElement } from 'slate';
+import { Descendant, BaseEditor, BaseElement, Node } from 'slate';
 import { ReactEditor } from 'slate-react';
 import { HistoryEditor } from 'slate-history';
 import { IDialogController } from '../modal-dialog/dialog-types';
@@ -123,6 +123,12 @@ export type CustomElement =
   // | TitleElement
   | UnknownElement;
   // | VideoElement
+
+// type guard for whether a Node is an Element
+export function isCustomElement(elt: Node): elt is CustomElement {
+  return "children" in elt && Array.isArray(elt.children) &&
+          "type" in elt && elt.type != null;
+}
 
 export type CustomText = {
   bold?: boolean;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 export { BaseElement, BaseSelection, Descendant, Editor, Node, Range, Transforms } from "slate";
 export { ReactEditor, RenderElementProps, Slate, useFocused, useSelected, useSlate } from "slate-react";
-export { CustomEditor, CustomElement, CustomText } from "./common/custom-types";
+export { CustomEditor, CustomElement, CustomText, isCustomElement } from "./common/custom-types";
 export {
   EditorValue, EFormat, kSlateVoidClass, slateToText, textToSlate
 } from "./common/slate-types";


### PR DESCRIPTION
## Version 0.10.1 - July 24, 2024

### Features/Improvements
- Export `isCustomElement()` function

### Bugs Fixed
- Fix bug in `ReactEditor.focus()` by downgrading to `slate-react` 0.98.4