### PR TITLE
chore: fix .travis.yml by eliminating deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,16 @@ cache:
   bundler: true
   pip: true
   npm: true
-before_install:
-- pyenv local 3.6
+# before_install:
+# - pyenv local 3.6
 install:
-- travis_retry gem install s3_website -v 3.4.0
-- travis_retry pip install awscli --upgrade --user
+# - travis_retry gem install s3_website -v 3.4.0
+# - travis_retry pip install awscli --upgrade --user
 - travis_retry npm ci
 script:
 - npm run lint
 - npm run test
 - npm run build
-- npm run build:storybook
-after_success:
-- ./.travis-deploy.sh
+# - npm run build:storybook
+# after_success:
+# - ./.travis-deploy.sh


### PR DESCRIPTION
The old Travis deploy system no longer works, so we simply comment out the deploy steps so the CI build completes successfully as long as the code builds.