### PR TITLE
fix: forward onChange options through SlateEditor wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 0.13.0-pre.0 - May 13, 2026
+- Fixed `SlateEditor` wrapper to forward the `options` argument when invoking the original `editor.onChange`, so consumers of `<Slate onValueChange>` / `<Slate onSelectionChange>` correctly distinguish value vs. selection changes.
+
 ## Version 0.12.0 - September 26, 2025
 - [Breaking] Minimum React version is 18
 - Improved support for external toolbars

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@concord-consortium/slate-editor",
-  "version": "0.12.0",
+  "version": "0.13.0-pre.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@concord-consortium/slate-editor",
-      "version": "0.12.0",
+      "version": "0.13.0-pre.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/css": "^11.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/slate-editor",
-  "version": "0.12.0",
+  "version": "0.13.0-pre.0",
   "description": "Slate-based rich text editor component for use in CC projects",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/slate-editor/slate-editor.test.tsx
+++ b/src/slate-editor/slate-editor.test.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 // not being picked up from `jest.setup.ts` for some reason
 import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
+import { Transforms } from "slate";
 import { Slate } from "slate-react";
 import { EditorValue, slateToText, textToSlate } from "../common/slate-types";
 import { IProps as ISlateEditorProps, SlateEditor } from "./slate-editor";
@@ -65,5 +66,69 @@ describe("Slate Editor", () => {
       );
     });
 
+  });
+
+  describe("Slate onChange options forwarding", () => {
+    // Regression test for the SlateEditor wrapper dropping the options argument
+    // when forwarding to <Slate>'s onContextChange. Without forwarding, set_selection
+    // ops also trigger onValueChange (because the switch on options.operation.type
+    // falls through to the default branch when options is undefined).
+    it("dispatches set_selection ops to onSelectionChange, not onValueChange", async () => {
+      const onValueChange = jest.fn();
+      const onSelectionChange = jest.fn();
+      const editor = createEditor({ history: true });
+      const initialValue = textToSlate("hello");
+
+      render(
+        <Slate
+          editor={editor}
+          initialValue={initialValue}
+          onValueChange={onValueChange}
+          onSelectionChange={onSelectionChange}
+        >
+          <SlateEditor />
+        </Slate>
+      );
+
+      onValueChange.mockClear();
+      onSelectionChange.mockClear();
+
+      await act(async () => {
+        Transforms.select(editor, { path: [0, 0], offset: 1 });
+        // slate batches editor.onChange onto a microtask; flush it
+        await Promise.resolve();
+      });
+
+      expect(onSelectionChange).toHaveBeenCalled();
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
+
+    it("dispatches value ops to onValueChange", async () => {
+      const onValueChange = jest.fn();
+      const onSelectionChange = jest.fn();
+      const editor = createEditor({ history: true });
+      const initialValue = textToSlate("hello");
+
+      render(
+        <Slate
+          editor={editor}
+          initialValue={initialValue}
+          onValueChange={onValueChange}
+          onSelectionChange={onSelectionChange}
+        >
+          <SlateEditor />
+        </Slate>
+      );
+
+      onValueChange.mockClear();
+      onSelectionChange.mockClear();
+
+      await act(async () => {
+        Transforms.insertText(editor, "!", { at: { path: [0, 0], offset: 5 } });
+        await Promise.resolve();
+      });
+
+      expect(onValueChange).toHaveBeenCalled();
+    });
   });
 });

--- a/src/slate-editor/slate-editor.tsx
+++ b/src/slate-editor/slate-editor.tsx
@@ -1,6 +1,6 @@
 import isHotkey from 'is-hotkey';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
-import { Descendant } from 'slate';
+import { Descendant, Operation } from 'slate';
 import { Editable, RenderElementProps, RenderLeafProps, useSlate } from 'slate-react';
 
 import { Element } from './element';
@@ -32,15 +32,15 @@ export const SlateEditor = ({
   className, placeholder, readOnly, hotkeyMap, historyKeys, onBlur, onChange, onFocus
 }: IProps) => {
   const editor = useSlate();
-  const origOnChangeRef = useRef<() => void>();
+  const origOnChangeRef = useRef<(options?: { operation?: Operation }) => void>();
 
   useEffect(() => {
     origOnChangeRef.current = editor.onChange;
   }, [editor]);
 
   useEffect(() => {
-    editor.onChange = () => {
-      origOnChangeRef.current?.();
+    editor.onChange = (options?: { operation?: Operation }) => {
+      origOnChangeRef.current?.(options);
       onChange?.(editor.children);
     };
   }, [editor, onChange]);


### PR DESCRIPTION
## Summary

The `SlateEditor` component wraps `editor.onChange` so it can fire its own `onChange` prop alongside the original handler, but the wrapper dropped the `options` argument when forwarding. The original handler is `<Slate>`'s `onContextChange`, which uses `options.operation.type` to decide whether to call `onValueChange` vs. `onSelectionChange`. Without `options`, that switch always falls into the default branch and fires `onValueChange` for `set_selection` ops too — the value/selection distinction is lost.

## Change

`src/slate-editor/slate-editor.tsx` — type the `origOnChangeRef` to accept the slate `options` argument, and forward `options` to the original onChange when invoking it. One file, 4 line change.

```diff
-  const origOnChangeRef = useRef<() => void>();
+  const origOnChangeRef = useRef<(options?: { operation?: Operation }) => void>();

-    editor.onChange = () => {
-      origOnChangeRef.current?.();
+    editor.onChange = (options?: { operation?: Operation }) => {
+      origOnChangeRef.current?.(options);
       onChange?.(editor.children);
     };
```

## Why this matters

Discovered while debugging a CLUE redo regression on React 18 (CLUE-489). Slate's `editor.onChange` is now microtask-batched, so a `Transforms.select` dispatched from a model-driven update fires an async `set_selection` onChange. CLUE's consumer code intended to subscribe via `<Slate onValueChange>` to ignore these selection-only events, but the wrapper bug meant `onValueChange` fired for every op, including the stray `set_selection`, which then wrote back to the MST model and clobbered the redo stack.

With the fix, `<Slate onValueChange>` and `<Slate onSelectionChange>` correctly distinguish value vs. selection changes for downstream consumers.

## Regression test

`src/slate-editor/slate-editor.test.tsx` — two cases added under a new `Slate onChange options forwarding` describe block:

- `Transforms.select` → `<Slate>` fires `onSelectionChange`, not `onValueChange`. Fails on master because `options` is dropped before reaching `<Slate>`'s switch.
- `Transforms.insertText` → `<Slate>` fires `onValueChange`. Baseline / sanity check.

## Test plan
- [x] New regression tests fail on master, pass with the fix
- [x] `npm test` in slate-editor passes (49 tests / 7 suites)
- [x] CLUE consumer test passes against `@concord-consortium/slate-editor@0.13.0-pre.0` — the redo regression is resolved
- [x] CLUE Base + Regression CI passes against the same version