### PR TITLE
chore: prepare release 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version 0.13.0-pre.0 - May 13, 2026
+## Version 0.13.0 - May 26, 2026
 - Fixed `SlateEditor` wrapper to forward the `options` argument when invoking the original `editor.onChange`, so consumers of `<Slate onValueChange>` / `<Slate onSelectionChange>` correctly distinguish value vs. selection changes.
 
 ## Version 0.12.0 - September 26, 2025

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@concord-consortium/slate-editor",
-  "version": "0.13.0-pre.0",
+  "version": "0.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@concord-consortium/slate-editor",
-      "version": "0.13.0-pre.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/css": "^11.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/slate-editor",
-  "version": "0.13.0-pre.0",
+  "version": "0.13.0",
   "description": "Slate-based rich text editor component for use in CC projects",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
## Summary
- Promote the `0.13.0-pre.0` changelog entry to the final `0.13.0` entry (dated May 26, 2026)
- Bump `package.json` and `package-lock.json` from `0.13.0-pre.0` to `0.13.0`

## Test plan
- [ ] CI passes on the release branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)